### PR TITLE
feat: add file watching for pages

### DIFF
--- a/packages/react-pages/src/node/dynamic-modules/find-pages-strategy/default.ts
+++ b/packages/react-pages/src/node/dynamic-modules/find-pages-strategy/default.ts
@@ -1,22 +1,16 @@
-import { globFind } from './utils'
-import type { FindPagesHelpers, PageData } from '../pages'
+import type { PageStrategy } from '../pages'
 
-export async function defaultFindPages(
-  pagesDirPath: string,
-  findPagesHelpers: FindPagesHelpers
-): Promise<PageData[]> {
-  const pages = await globFind(pagesDirPath, '**/*$.{md,mdx,js,jsx,ts,tsx}')
-
-  return Promise.all(
-    pages.map(async ({ relative, absolute }) => {
-      const pagePublicPath = getPagePublicPath(relative)
-      return {
-        pageId: pagePublicPath,
-        dataPath: absolute,
-        staticData: await findPagesHelpers.extractStaticData(absolute),
-      }
-    })
-  )
+export const defaultStrategy: Required<PageStrategy> = {
+  findPages: (pagesDirPath, { globFind }) =>
+    globFind(pagesDirPath, '**/*$.{md,mdx,js,jsx,ts,tsx}'),
+  async loadPageData({ relative, absolute }, { extractStaticData }) {
+    const pagePublicPath = getPagePublicPath(relative)
+    return {
+      pageId: pagePublicPath,
+      dataPath: absolute,
+      staticData: await extractStaticData(absolute),
+    }
+  },
 }
 
 function getPagePublicPath(relativePageFilePath: string) {

--- a/packages/react-pages/src/node/dynamic-modules/find-pages-strategy/utils.ts
+++ b/packages/react-pages/src/node/dynamic-modules/find-pages-strategy/utils.ts
@@ -1,10 +1,15 @@
 import globby from 'globby'
 import * as path from 'path'
 
+export interface PagePath {
+  readonly relative: string
+  readonly absolute: string
+}
+
 export async function globFind(
   baseDir: string,
   glob: string
-): Promise<{ relative: string; absolute: string }[]> {
+): Promise<PagePath[]> {
   const pageFiles: string[] = await globby(glob, {
     cwd: baseDir,
     ignore: ['**/node_modules/**/*'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,7 @@ importers:
       react: 17.0.1
       react-dom: 17.0.1_react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
+      vite-pages-theme-basic: link:../../theme-basic
     devDependencies:
       '@types/node': 14.14.31
       '@types/react': 17.0.2
@@ -236,7 +237,6 @@ importers:
       sass: 1.32.8
       serve: 11.3.2
       vite: 2.0.1
-      vite-pages-theme-basic: link:../../theme-basic
       vite-plugin-mdx: link:../../vite-plugin-mdx
       vite-plugin-react-pages: link:../../react-pages
     specifiers:
@@ -258,6 +258,7 @@ importers:
       react: 17.0.1
       react-dom: 17.0.1_react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
+      vite-pages-theme-basic: link:../../theme-basic
     devDependencies:
       '@types/node': 14.14.31
       '@types/react': 17.0.2
@@ -265,7 +266,6 @@ importers:
       serve: 11.3.2
       typescript: 4.1.5
       vite: 2.0.1
-      vite-pages-theme-basic: link:../../theme-basic
       vite-plugin-mdx: link:../../vite-plugin-mdx
       vite-plugin-react-pages: link:../../react-pages
     specifiers:
@@ -306,6 +306,7 @@ importers:
       react: 17.0.1
       react-dom: 17.0.1_react@17.0.1
       react-router-dom: 5.2.0_react@17.0.1
+      vite-pages-theme-basic: link:../../../../theme-basic
     devDependencies:
       '@types/node': 14.14.31
       '@types/react': 17.0.2
@@ -316,7 +317,6 @@ importers:
       my-card: link:../card
       serve: 11.3.2
       vite: 2.0.1
-      vite-pages-theme-basic: link:../../../../theme-basic
       vite-plugin-mdx: link:../../../../vite-plugin-mdx
       vite-plugin-react-pages: link:../../../../react-pages
     specifiers:


### PR DESCRIPTION
I'm using `chokidar` for file watching.

- Pages have their static data reloaded when their file is changed.
- New pages are detected using the globs passed to the `globFind` helper.
- Deleted pages are removed from the cache during development.

Also, I added a `loadPageData` option that allows overriding data-loading
by the default strategy without overriding how it finds the pages.

The `defaultFindPages` helper has been replaced by the `findPages` and
`loadPageData` helpers. For this reason, this commit is a **breaking change.**