### PR TITLE
fix: ensure custom `loadPageData` can call the default loader

### DIFF
--- a/packages/react-pages/src/node/dynamic-modules/PageStrategy.ts
+++ b/packages/react-pages/src/node/dynamic-modules/PageStrategy.ts
@@ -39,7 +39,7 @@ export class PageStrategy extends EventEmitter {
 
     const helpers: PageHelpers = {
       extractStaticData,
-      loadPageData: (file) => Promise.resolve(loadPageData(file, helpers)),
+      loadPageData: defaultPageLoader,
       addPageData,
       watchFiles,
     }
@@ -48,7 +48,10 @@ export class PageStrategy extends EventEmitter {
     let currentFile: File | null = null
 
     let pagesPromise = Promise.resolve(pageCache)
-    findPages(pagesDir, helpers)
+    findPages(pagesDir, {
+      ...helpers,
+      loadPageData: (file) => Promise.resolve(loadPageData(file, helpers)),
+    })
 
     this.getPages = () => pagesPromise
     this.close = () => watchers.forEach((w) => w.close())


### PR DESCRIPTION
With this commit, the helpers object passed to `findPages` and `loadPageData` will be slightly different. The `findPages` function can still call the custom `loadPageData`, but the `loadPageData` function can only call the default page loader.

```ts
import reactPages from 'vite-plugin-react-pages'

export default {
	plugins: [
		reactPages({
			async loadPageData(file, { loadPageData }) {
				const defaultData = await loadPageData(file)
				return { ...defaultData, custom: 'data' }
			}
		})
	]
}
```