### PR TITLE
feat: strip frontmatter by default

### DIFF
--- a/packages/create-project/template-app/package.json
+++ b/packages/create-project/template-app/package.json
@@ -24,7 +24,7 @@
     "sass": "^1.32.8",
     "serve": "^11.3.2",
     "vite": "^2.0.1",
-    "vite-plugin-mdx": "workspace:^2.0.1",
+    "vite-plugin-mdx": "^3.0.0",
     "vite-plugin-react-pages": "workspace:^2.1.0"
   }
 }

--- a/packages/create-project/template-lib/package.json
+++ b/packages/create-project/template-lib/package.json
@@ -21,7 +21,7 @@
     "serve": "^11.3.2",
     "typescript": "^4.1.5",
     "vite": "^2.0.1",
-    "vite-plugin-mdx": "workspace:^2.0.1",
+    "vite-plugin-mdx": "^3.0.0",
     "vite-plugin-react-pages": "workspace:^2.1.0"
   }
 }

--- a/packages/react-pages/package.json
+++ b/packages/react-pages/package.json
@@ -58,6 +58,7 @@
     "jest-docblock": "^26.0.0",
     "mini-debounce": "^1.0.8",
     "minimist": "^1.2.5",
+    "nomatter": "^0.1.0",
     "ora": "^5.3.0",
     "query-string": "^6.14.0",
     "read-pkg-up": "^7.0.1",

--- a/packages/react-pages/src/node/index.ts
+++ b/packages/react-pages/src/node/index.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import type { Plugin } from 'vite'
+import noMatter from 'nomatter'
 import {
   renderPageList,
   renderPageListInSSR,
@@ -37,6 +38,7 @@ export default function pluginFactory(
 
   return {
     name: 'vite-plugin-react-pages',
+    enforce: 'pre',
     config: () => ({
       resolve: {
         alias: {
@@ -64,6 +66,11 @@ export default function pluginFactory(
         .on('change', (pageId: string) =>
           watcher.emit('change', pagesModuleId + pageId)
         )
+    },
+    transform(code, id) {
+      if (/\.mdx$/.test(id)) {
+        return noMatter(code)
+      }
     },
     resolveId(id) {
       return id === themeModuleId ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,7 @@ importers:
       jest-docblock: 26.0.0
       mini-debounce: 1.0.8
       minimist: 1.2.5
+      nomatter: 0.1.0
       ora: 5.3.0
       query-string: 6.14.0
       read-pkg-up: 7.0.1
@@ -427,6 +428,7 @@ importers:
       jest-docblock: ^26.0.0
       mini-debounce: ^1.0.8
       minimist: ^1.2.5
+      nomatter: ^0.1.0
       ora: ^5.3.0
       query-string: ^6.14.0
       react: ^17.0.1
@@ -5822,6 +5824,10 @@ packages:
   /node-releases/1.1.69:
     resolution:
       integrity: sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==
+  /nomatter/0.1.0:
+    dev: false
+    resolution:
+      integrity: sha512-0LibFP+EcAthuxln7E2bZT7iueusTND7EnrH9QV2B+4sS0Yyw9Pu5yli6eb7rAvbzByMCkku4DD9CTYeSIk8gA==
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.8


### PR DESCRIPTION
This makes react-pages compatible with `vite-plugin-mdx@3.0.0` (which does *not* include `remark-frontmatter` by default). I think having react-pages remove the frontmatter (via `transform` hook) is better than forcing the developer to add remark-frontmatter to their dependencies.

[The library](https://github.com/aleclarson/nomatter/blob/master/index.js) I use to remove the frontmatter has no dependencies and it does not parse the YAML within.