### PR TITLE
feat: inject remark-frontmatter if missing

### DIFF
--- a/packages/create-project/template-app/package.json
+++ b/packages/create-project/template-app/package.json
@@ -24,7 +24,7 @@
     "sass": "^1.32.8",
     "serve": "^11.3.2",
     "vite": "^2.0.1",
-    "vite-plugin-mdx": "workspace:^2.0.1",
+    "vite-plugin-mdx": "^3.1.0",
     "vite-plugin-react-pages": "workspace:^2.1.0"
   }
 }

--- a/packages/create-project/template-lib/package.json
+++ b/packages/create-project/template-lib/package.json
@@ -21,7 +21,7 @@
     "serve": "^11.3.2",
     "typescript": "^4.1.5",
     "vite": "^2.0.1",
-    "vite-plugin-mdx": "workspace:^2.0.1",
+    "vite-plugin-mdx": "^3.1.0",
     "vite-plugin-react-pages": "workspace:^2.1.0"
   }
 }

--- a/packages/react-pages/package.json
+++ b/packages/react-pages/package.json
@@ -63,7 +63,6 @@
     "query-string": "^6.14.0",
     "read-pkg-up": "^7.0.1",
     "remark-frontmatter": "^2.0.0",
-    "resolve-from": "^5.0.0",
     "rollup": "^2.39.0",
     "rollup-plugin-postcss": "^4.0.0",
     "slash": "^3.0.0",

--- a/packages/react-pages/package.json
+++ b/packages/react-pages/package.json
@@ -42,7 +42,8 @@
     "concurrently": "^6.0.0",
     "react": "^17.0.1",
     "typescript": "^4.1.5",
-    "vite": "^2.0.1"
+    "vite": "^2.0.1",
+    "vite-plugin-mdx": "^3.1.0"
   },
   "dependencies": {
     "@babel/preset-react": "^7.12.13",
@@ -61,6 +62,8 @@
     "ora": "^5.3.0",
     "query-string": "^6.14.0",
     "read-pkg-up": "^7.0.1",
+    "remark-frontmatter": "^3.0.0",
+    "resolve-from": "^5.0.0",
     "rollup": "^2.39.0",
     "rollup-plugin-postcss": "^4.0.0",
     "slash": "^3.0.0",

--- a/packages/react-pages/package.json
+++ b/packages/react-pages/package.json
@@ -62,7 +62,7 @@
     "ora": "^5.3.0",
     "query-string": "^6.14.0",
     "read-pkg-up": "^7.0.1",
-    "remark-frontmatter": "^3.0.0",
+    "remark-frontmatter": "^2.0.0",
     "resolve-from": "^5.0.0",
     "rollup": "^2.39.0",
     "rollup-plugin-postcss": "^4.0.0",

--- a/packages/react-pages/src/node/index.ts
+++ b/packages/react-pages/src/node/index.ts
@@ -1,7 +1,6 @@
 import * as path from 'path'
 import type { Plugin } from 'vite'
 import type { MdxPlugin } from 'vite-plugin-mdx'
-import resolve from 'resolve-from'
 import {
   renderPageList,
   renderPageListInSSR,
@@ -61,7 +60,8 @@ export default function pluginFactory(
       pageStrategy = new PageStrategy(pagesDir, findPages, loadPageData)
 
       // Inject parsing logic for frontmatter if missing.
-      if (!resolve.silent(root, 'remark-frontmatter')) {
+      const { devDependencies = {} } = require(path.join(root, 'package.json'))
+      if (!devDependencies['remark-frontmatter']) {
         const mdxPlugin = plugins.find(
           (plugin) => plugin.name === 'vite-plugin-mdx'
         ) as MdxPlugin | undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
       gh-pages: 3.1.0
       serve: 11.3.2
       vite: 2.0.1
-      vite-plugin-mdx: link:../packages/vite-plugin-mdx
+      vite-plugin-mdx: link:../packages/react-pages/vendor/vite-plugin-mdx
       vite-plugin-react-pages: link:../packages/react-pages
     specifiers:
       '@types/react': ^17.0.2
@@ -64,7 +64,7 @@ importers:
       sass: 1.32.8
       serve: 11.3.2
       vite: 2.0.1
-      vite-plugin-mdx: link:../../packages/vite-plugin-mdx
+      vite-plugin-mdx: link:../../packages/react-pages/vendor/vite-plugin-mdx
       vite-plugin-react: 4.0.1_vite@2.0.1
       vite-plugin-react-pages: link:../../packages/react-pages
     specifiers:
@@ -95,7 +95,7 @@ importers:
       '@vitejs/plugin-react-refresh': 1.3.1
       sass: 1.32.8
       vite: 2.0.1
-      vite-plugin-mdx: link:../../packages/vite-plugin-mdx
+      vite-plugin-mdx: link:../../packages/react-pages/vendor/vite-plugin-mdx
       vite-plugin-react-pages: link:../../packages/react-pages
     specifiers:
       '@types/react': ^17.0.2
@@ -121,7 +121,7 @@ importers:
       globby: 11.0.2
       serve: 11.3.2
       vite: 2.0.1
-      vite-plugin-mdx: link:../../packages/vite-plugin-mdx
+      vite-plugin-mdx: link:../../packages/react-pages/vendor/vite-plugin-mdx
       vite-plugin-react-pages: link:../../packages/react-pages
     specifiers:
       '@types/react': ^17.0.2
@@ -159,7 +159,7 @@ importers:
       my-lib: link:../library
       serve: 11.3.2
       vite: 2.0.1
-      vite-plugin-mdx: link:../../packages/vite-plugin-mdx
+      vite-plugin-mdx: link:../../packages/react-pages/vendor/vite-plugin-mdx
       vite-plugin-react-pages: link:../../packages/react-pages
     specifiers:
       '@types/react': ^17.0.2
@@ -221,7 +221,7 @@ importers:
       '@vitejs/plugin-react-refresh': 1.3.1
       serve: 11.3.2
       vite: 2.0.1
-      vite-plugin-mdx: link:../../packages/vite-plugin-mdx
+      vite-plugin-mdx: link:../../packages/react-pages/vendor/vite-plugin-mdx
       vite-plugin-react-pages: link:../../packages/react-pages
     specifiers:
       '@types/react': ^17.0.2
@@ -370,7 +370,7 @@ importers:
       '@vitejs/plugin-react-refresh': 1.3.1
       sass: 1.32.8
       vite: 2.0.1
-      vite-plugin-mdx: link:../../vite-plugin-mdx
+      vite-plugin-mdx: link:../../react-pages/vendor/vite-plugin-mdx
       vite-plugin-react-pages: link:../../react-pages
     specifiers:
       '@types/react': ^17.0.2
@@ -411,6 +411,8 @@ importers:
       ora: 5.3.0
       query-string: 6.14.0
       read-pkg-up: 7.0.1
+      remark-frontmatter: 3.0.0
+      resolve-from: 5.0.0
       rollup: 2.39.0
       rollup-plugin-postcss: 4.0.0
       slash: 3.0.0
@@ -428,6 +430,7 @@ importers:
       react: 17.0.1
       typescript: 4.1.5
       vite: 2.0.1
+      vite-plugin-mdx: link:vendor/vite-plugin-mdx
     specifiers:
       '@babel/preset-react': ^7.12.13
       '@babel/preset-typescript': ^7.12.17
@@ -455,12 +458,15 @@ importers:
       query-string: ^6.14.0
       react: ^17.0.1
       read-pkg-up: ^7.0.1
+      remark-frontmatter: ^3.0.0
+      resolve-from: ^5.0.0
       rollup: ^2.39.0
       rollup-plugin-postcss: ^4.0.0
       slash: ^3.0.0
       tiny-invariant: ^1.1.0
       typescript: ^4.1.5
       vite: ^2.0.1
+      vite-plugin-mdx: ^3.0.0
   packages/theme-basic:
     dependencies:
       github-markdown-css: 4.0.0
@@ -934,7 +940,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.9:
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.12.13
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.9
       '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.12.9
     dev: false
@@ -1093,7 +1099,7 @@ packages:
   /@babel/plugin-transform-parameters/7.12.1_@babel+core@7.12.9:
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.12.13
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -5589,6 +5595,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==
+  /mdast-util-frontmatter/0.2.0:
+    dependencies:
+      micromark-extension-frontmatter: 0.2.2
+    dev: false
+    resolution:
+      integrity: sha512-FHKL4w4S5fdt1KjJCwB0178WJ0evnyyQr5kXTM3wrOVpytD0hrkvd+AOOjU9Td8onOejCkmZ+HQRT3CZ3coHHQ==
   /mdast-util-to-hast/10.0.1:
     dependencies:
       '@types/mdast': 3.0.3
@@ -5637,6 +5649,12 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+  /micromark-extension-frontmatter/0.2.2:
+    dependencies:
+      fault: 1.0.4
+    dev: false
+    resolution:
+      integrity: sha512-q6nPLFCMTLtfsctAuS0Xh4vaolxSFUWUWR6PZSrXXiRy+SANGllpcqdXFv2z07l0Xz/6Hl40hK0ffNCJPH2n1A==
   /micromatch/3.1.10:
     dependencies:
       arr-diff: 4.0.0
@@ -7590,6 +7608,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-uNOQt4tO14qBFWXenF0MLC4cqo3dv8qiHPGyjCl1rwOT0LomSHpcElbjjVh5CwzElInB38HD8aSRVugKQjeyHA==
+  /remark-frontmatter/3.0.0:
+    dependencies:
+      mdast-util-frontmatter: 0.2.0
+      micromark-extension-frontmatter: 0.2.2
+    dev: false
+    resolution:
+      integrity: sha512-mSuDd3svCHs+2PyO29h7iijIZx4plX0fheacJcAoYAASfgzgVIcXGYSq9GFyYocFLftQs8IOmmkgtOovs6d4oA==
   /remark-mdx/1.6.22:
     dependencies:
       '@babel/core': 7.12.9


### PR DESCRIPTION
Depends on https://github.com/brillout/vite-plugin-mdx/pull/11

- In `configResolved` hook, check if `remark-frontmatter` is installed by project

- If it is, do nothing.

- Otherwise, find a plugin named `vite-plugin-mdx` that has a `mdxOptions` property
    
  - If no plugin is found, warn the user to upgrade or install `vite-plugin-mdx`

  - Otherwise, inject `remark-frontmatter` into the `mdxOptions.remarkPlugins` array