### PR TITLE
refactor: new findPages api using proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "overrides": {
       "react": "^17.0.1",
       "react-dom": "^17.0.1",
-      "esbuild": "0.8.57"
+      "esbuild": "^0.9.3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "pnpm": {
     "overrides": {
       "react": "^17.0.1",
-      "react-dom": "^17.0.1"
+      "react-dom": "^17.0.1",
+      "esbuild": "0.8.57"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/jest": "^26.0.19",
     "@types/node": "^14.14.34",
     "jest": "^26.6.3",
-    "playwright-chromium": "^1.7.0",
+    "playwright-chromium": "~1.9.2",
     "sirv": "^1.0.10",
     "slash": "^3.0.0",
     "ts-jest": "^26.4.4",

--- a/packages/playground/custom-find-pages/vite.config.ts
+++ b/packages/playground/custom-find-pages/vite.config.ts
@@ -2,7 +2,7 @@ import type { UserConfig } from 'vite'
 import * as path from 'path'
 import reactRefresh from '@vitejs/plugin-react-refresh'
 import mdx from 'vite-plugin-mdx'
-import pages, { defaultPageFinder } from 'vite-plugin-react-pages'
+import pages, { DefaultPageStrategy } from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
@@ -11,28 +11,28 @@ module.exports = {
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),
-      findPages: async (pagesDir, helpers) => {
-        const demosBasePath = path.join(__dirname, 'src')
-        // find all demo modules
-        helpers.watchFiles({
-          baseDir: demosBasePath,
-          globs: '*/demos/**/*.{[tj]sx,md?(x)}',
-          async fileHandler(file, api) {
-            const { relative, path: absolute } = file
-            const match = relative.match(/(.*)\/demos\/(.*)\.([tj]sx|mdx?)$/)
-            if (!match) throw new Error('unexpected file: ' + absolute)
-            const [_, componentName, demoPath] = match
-            const pageId = `/${componentName}`
-            const runtimeDataPaths = api.getRuntimeData(pageId)
-            runtimeDataPaths[demoPath] = absolute
-            const staticDataPaths = api.getStaticData(pageId)
-            staticDataPaths[demoPath] = await helpers.extractStaticData(file)
-            staticDataPaths.title = `${componentName} Title`
-          },
-        })
-        // we also want to collect pages from `/pages` with basic filesystem routing convention
-        defaultPageFinder(pagesDir, helpers)
-      },
+      pageStrategy: new DefaultPageStrategy({
+        extraFindPages: async (pagesDir, helpers) => {
+          const demosBasePath = path.join(__dirname, 'src')
+          // find all demo modules
+          helpers.watchFiles(
+            demosBasePath,
+            '*/demos/**/*.{[tj]sx,md?(x)}',
+            async function fileHandler(file, api) {
+              const { relative, path: absolute } = file
+              const match = relative.match(/(.*)\/demos\/(.*)\.([tj]sx|mdx?)$/)
+              if (!match) throw new Error('unexpected file: ' + absolute)
+              const [_, componentName, demoPath] = match
+              const pageId = `/${componentName}`
+              const runtimeDataPaths = api.getRuntimeData(pageId)
+              runtimeDataPaths[demoPath] = absolute
+              const staticDataPaths = api.getStaticData(pageId)
+              staticDataPaths[demoPath] = await helpers.extractStaticData(file)
+              staticDataPaths.title = `${componentName} Title`
+            }
+          )
+        },
+      }),
     }),
   ],
   resolve: {

--- a/packages/playground/custom-find-pages/vite.config.ts
+++ b/packages/playground/custom-find-pages/vite.config.ts
@@ -30,8 +30,9 @@ module.exports = {
               dataPath: absolute,
               staticData: await helpers.extractStaticData(file),
             })
-            // set page's title
-            // currently doesn't work
+            // want to set page's title
+            // currently throw addPageData conflict: staticData with key "title" already exists
+            // because other demo files have set it
             helpers.addPageData({
               pageId: publicPath,
               key: 'title',

--- a/packages/react-pages/package.json
+++ b/packages/react-pages/package.json
@@ -51,6 +51,7 @@
     "chokidar": "^3.5.1",
     "dequal": "^2.0.2",
     "enhanced-resolve": "^5.7.0",
+    "fast-deep-equal": "^3.1.3",
     "fs-extra": "^9.1.0",
     "gray-matter": "^4.0.2",
     "jest-docblock": "^26.0.0",

--- a/packages/react-pages/src/client/state.ts
+++ b/packages/react-pages/src/client/state.ts
@@ -96,15 +96,14 @@ if (import.meta.hot) {
 
   const dataAtoms = atomFamily((path: string) => (get) => {
     const pages = get(pagesAtom)
-    const page = pages[path] || pages['/404']
-    return page || null
+    return pages[path]
   })
 
   const emptyData: any = {}
   const staticDataAtoms = atomFamily((path: string) => (get) => {
     const pages = get(pagesAtom)
-    const page = pages[path] || pages['/404']
-    return page?.staticData || emptyData
+    const page = pages[path]
+    return page?.staticData
   })
 
   usePagePaths = () => {
@@ -112,13 +111,9 @@ if (import.meta.hot) {
     return useAtomValue(pagePathsAtom)
   }
 
-  // This hook uses dynamic import with a variable, which is not supported
-  // by Rollup, but that's okay since HMR is for development only.
   usePageModule = (pagePath) => {
     const data = useAtomValue(dataAtoms(pagePath))
-    return useMemo(() => {
-      return data ? data.data() : void 0
-    }, [data])
+    return useMemo(() => data?.data(), [data])
   }
 
   useStaticData = (pagePath?: string, selector?: Function) => {
@@ -139,12 +134,12 @@ else {
   useTheme = () => initialTheme
   usePagePaths = () => initialPagePaths
   usePageModule = (path) => {
-    const page = initialPages[path] || initialPages['/404']
+    const page = initialPages[path]
     return useMemo(() => page?.data(), [page])
   }
   useStaticData = (path?: string, selector?: Function) => {
     if (path) {
-      const page = initialPages[path] || initialPages['/404']
+      const page = initialPages[path]
       const staticData = page?.staticData || {}
       return selector ? selector(staticData) : staticData
     }

--- a/packages/react-pages/src/client/state.ts
+++ b/packages/react-pages/src/client/state.ts
@@ -17,6 +17,10 @@ interface PageModule {
 import initialPages from '/@react-pages/pages'
 import initialTheme from '/@react-pages/theme'
 
+// TODO: simplify this
+// there is no easy way to handle the hmr of module such as `/@react-pages/pages/page1` so stop trying it
+// https://github.com/vitejs/vite-plugin-react-pages/pull/19#discussion_r604251258
+
 const initialPagePaths = Object.keys(initialPages)
 
 // This HMR code assumes that our Jotai atoms are always managed
@@ -99,7 +103,6 @@ if (import.meta.hot) {
     return pages[path]
   })
 
-  const emptyData: any = {}
   const staticDataAtoms = atomFamily((path: string) => (get) => {
     const pages = get(pagesAtom)
     const page = pages[path]
@@ -113,11 +116,7 @@ if (import.meta.hot) {
 
   usePageModule = (pagePath) => {
     const data = useAtomValue(dataAtoms(pagePath))
-    // if the dataModulePath hasn't changed,
-    // we can keep using the same dataModule.
-    // vite hmr will handle it's update.
-    // (all dataModules should be self-accepted)
-    return useMemo(() => data?.data(), [data.dataModulePath])
+    return useMemo(() => data?.data(), [data])
   }
 
   useStaticData = (pagePath?: string, selector?: Function) => {

--- a/packages/react-pages/src/client/state.ts
+++ b/packages/react-pages/src/client/state.ts
@@ -94,10 +94,10 @@ if (import.meta.hot) {
     }
   })
 
-  const dataPathAtoms = atomFamily((path: string) => (get) => {
+  const dataAtoms = atomFamily((path: string) => (get) => {
     const pages = get(pagesAtom)
     const page = pages[path] || pages['/404']
-    return page?.dataPath || null
+    return page || null
   })
 
   const emptyData: any = {}
@@ -115,10 +115,10 @@ if (import.meta.hot) {
   // This hook uses dynamic import with a variable, which is not supported
   // by Rollup, but that's okay since HMR is for development only.
   usePageModule = (pagePath) => {
-    const dataPath = useAtomValue(dataPathAtoms(pagePath))
+    const data = useAtomValue(dataAtoms(pagePath))
     return useMemo(() => {
-      return dataPath ? import(dataPath /* @vite-ignore */) : void 0
-    }, [dataPath])
+      return data ? data.data() : void 0
+    }, [data])
   }
 
   useStaticData = (pagePath?: string, selector?: Function) => {

--- a/packages/react-pages/src/client/state.ts
+++ b/packages/react-pages/src/client/state.ts
@@ -113,7 +113,11 @@ if (import.meta.hot) {
 
   usePageModule = (pagePath) => {
     const data = useAtomValue(dataAtoms(pagePath))
-    return useMemo(() => data?.data(), [data])
+    // if the dataModulePath hasn't changed,
+    // we can keep using the same dataModule.
+    // vite hmr will handle it's update.
+    // (all dataModules should be self-accepted)
+    return useMemo(() => data?.data(), [data.dataModulePath])
   }
 
   useStaticData = (pagePath?: string, selector?: Function) => {

--- a/packages/react-pages/src/node/dynamic-modules/DefaultPageStrategy/index.ts
+++ b/packages/react-pages/src/node/dynamic-modules/DefaultPageStrategy/index.ts
@@ -3,11 +3,10 @@ import { extractStaticData } from '../utils'
 
 export class DefaultPageStrategy extends PageStrategy {
   constructor(
-    pagesDir: string,
     opts: { extraFindPages?: FindPages; fileHandler?: FileHandler } = {}
   ) {
     const { extraFindPages, fileHandler = defaultFileHandler } = opts
-    super(pagesDir, (pagesDir) => {
+    super((pagesDir) => {
       const helpers = this.createHelpers(fileHandler)
       helpers.watchFiles(pagesDir, '**/*$.{md,mdx,js,jsx,ts,tsx}')
       if (typeof extraFindPages === 'function') {

--- a/packages/react-pages/src/node/dynamic-modules/DefaultPageStrategy/index.ts
+++ b/packages/react-pages/src/node/dynamic-modules/DefaultPageStrategy/index.ts
@@ -1,0 +1,55 @@
+import { File, FileHandler, FindPages, PageStrategy } from '../PageStrategy'
+import { extractStaticData } from '../utils'
+
+export class DefaultPageStrategy extends PageStrategy {
+  constructor(
+    pagesDir: string,
+    opts: { extraFindPages?: FindPages; fileHandler?: FileHandler } = {}
+  ) {
+    const { extraFindPages, fileHandler = defaultFileHandler } = opts
+    super(pagesDir, (pagesDir) => {
+      const helpers = this.createHelpers(fileHandler)
+      helpers.watchFiles(pagesDir, '**/*$.{md,mdx,js,jsx,ts,tsx}')
+      if (typeof extraFindPages === 'function') {
+        extraFindPages(pagesDir, helpers)
+      }
+    })
+  }
+}
+
+/**
+ * The defaultFileHandler return the result to caller,
+ * instead of directly setting the pageData object.
+ * so that it is more useful to users.
+ */
+export const defaultFileHandler: FileHandler = async (
+  file: File,
+  fileHandlerAPI
+) => {
+  const pagePublicPath = getPagePublicPath(file.relative)
+  return {
+    pageId: pagePublicPath,
+    dataPath: file.path,
+    staticData: await extractStaticData(file),
+  }
+}
+
+export function getPagePublicPath(relativePageFilePath: string) {
+  let pagePublicPath = relativePageFilePath.replace(
+    /\$\.(md|mdx|js|jsx|ts|tsx)$/,
+    ''
+  )
+  pagePublicPath = pagePublicPath.replace(/index$/, '')
+  // ensure starting slash
+  pagePublicPath = pagePublicPath.replace(/\/$/, '')
+  pagePublicPath = `/${pagePublicPath}`
+
+  // turn [id] into :id
+  // so that react-router can recognize it as url params
+  pagePublicPath = pagePublicPath.replace(
+    /\[(.*?)\]/g,
+    (_, paramName) => `:${paramName}`
+  )
+
+  return pagePublicPath
+}

--- a/packages/react-pages/src/node/dynamic-modules/PageStrategy.ts
+++ b/packages/react-pages/src/node/dynamic-modules/PageStrategy.ts
@@ -12,7 +12,7 @@ import {
   PagesDataKeeper,
   PagesData,
   Association,
-  HanlderAPI,
+  HandlerAPI,
 } from './PagesData'
 import { UpdateBuffer } from './UpdateBuffer'
 
@@ -132,7 +132,7 @@ export interface FindPages {
   (pagesDir: string, helpers: PageHelpers): void | Promise<void>
 }
 
-export interface PageHelpers extends HanlderAPI {
+export interface PageHelpers extends HandlerAPI {
   /**
    * Read the static data from a file.
    */
@@ -172,7 +172,7 @@ export class File {
 }
 
 export interface FileHandler {
-  (file: File, api: HanlderAPI): void | Promise<void>
+  (file: File, api: HandlerAPI): void | Promise<void>
 }
 
 type WatchFilesHelper = (opts: {

--- a/packages/react-pages/src/node/dynamic-modules/PageStrategy.ts
+++ b/packages/react-pages/src/node/dynamic-modules/PageStrategy.ts
@@ -22,9 +22,9 @@ export class PageStrategy extends EventEmitter {
    */
   private pendingList = new PendingList()
 
-  constructor(private pagesDir: string, findPages: FindPages) {
+  constructor(private pagesDir: string, private findPages: FindPages) {
     super()
-    const { updateBuffer, pendingList } = this
+    const { updateBuffer } = this
 
     updateBuffer.on('page', (updates: string[]) => {
       this.emit('page', updates)
@@ -33,12 +33,15 @@ export class PageStrategy extends EventEmitter {
     updateBuffer.on('page-list', () => {
       this.emit('page-list')
     })
+  }
 
+  public start() {
     const helpers = this.createHelpers(() => {
       throw new Error(
         `No defaultFileHandler found. You should pass fileHandler argument when calling watchFiles`
       )
     })
+    const { findPages, pendingList, pagesDir } = this
     pendingList.addPending(Promise.resolve(findPages(pagesDir, helpers)))
   }
 

--- a/packages/react-pages/src/node/dynamic-modules/PagesData.ts
+++ b/packages/react-pages/src/node/dynamic-modules/PagesData.ts
@@ -1,0 +1,279 @@
+import { File } from './PageStrategy'
+import type { ScheduleUpdate } from './UpdateBuffer'
+
+export class PagesDataKeeper {
+  private pages: PagesDataInternal = {}
+
+  /**
+   * If the page page does not come from local file,
+   * then we create this api to track the source of page data.
+   * When a file is unlinked,
+   * the data associated with it will automatically get deleted.
+   */
+  createAPIForSourceFile(
+    sourceFile: File,
+    scheduleUpdate: ScheduleUpdate
+  ): HanlderAPI {
+    return {
+      getRuntimeData: (
+        pageId: string
+      ): {
+        [key: string]: string
+      } =>
+        this.createMutableProxy(pageId, 'runtime', sourceFile, scheduleUpdate),
+      getStaticData: (
+        pageId: string
+      ): {
+        [key: string]: any
+      } =>
+        this.createMutableProxy(pageId, 'static', sourceFile, scheduleUpdate),
+    }
+  }
+
+  /**
+   * If the page page does not come from local file (.e.g from remote database),
+   * then we can't track the source of page data.
+   */
+  createAPIForCustomSource(scheduleUpdate: ScheduleUpdate): HanlderAPI {
+    return {
+      getRuntimeData: (
+        pageId: string
+      ): {
+        [key: string]: string
+      } => this.createMutableProxy(pageId, 'runtime', null, scheduleUpdate),
+      getStaticData: (
+        pageId: string
+      ): {
+        [key: string]: any
+      } => this.createMutableProxy(pageId, 'static', null, scheduleUpdate),
+    }
+  }
+
+  private createMutableProxy(
+    pageId: string,
+    dataType: 'runtime' | 'static',
+    sourceFile: File | null,
+    scheduleUpdate: ScheduleUpdate
+  ): {
+    [key: string]: any
+  } {
+    const _this = this
+    const dataObj = this.getDataObj(pageId, dataType)
+    return new Proxy(dataObj, {
+      set(target, prop: string, value) {
+        // delete data with key 'prop'
+        if (value === undefined) {
+          const existValue = dataObj[prop]
+          if (existValue) {
+            existValue.unBind(scheduleUpdate)
+          }
+          return true
+        }
+        new Association(
+          _this,
+          pageId,
+          dataType,
+          prop,
+          value,
+          sourceFile,
+          scheduleUpdate
+        )
+        return true
+      },
+      get(target, prop: string) {
+        const association = target[prop]
+        if (association === undefined) return undefined
+        return association.value
+      },
+    })
+  }
+
+  toPagesData(): PagesData {
+    const result: PagesData = {}
+    Object.entries(this.pages).forEach(([pageId, page]) => {
+      if (this.isEmptyPage(pageId)) return
+
+      const runtimeData = Object.fromEntries(
+        Object.entries(page.runtimeData).map(([key, value]) => [
+          key,
+          value.value,
+        ])
+      )
+      const staticData = Object.fromEntries(
+        Object.entries(page.staticData).map(([key, value]) => [
+          key,
+          value.value,
+        ])
+      )
+      result[pageId] = {
+        data: runtimeData,
+        staticData,
+      }
+    })
+    return result
+  }
+
+  isEmptyPage(pageId: string) {
+    const page = this.pages[pageId]
+    if (!page) return true
+    const { runtimeData, staticData } = page
+    return (
+      Object.keys(runtimeData).length === 0 &&
+      Object.keys(staticData).length === 0
+    )
+  }
+
+  private initPageIfNotExist(pageId: string) {
+    let page = this.pages[pageId]
+    if (!page) {
+      page = this.pages[pageId] = { runtimeData: {}, staticData: {} }
+    }
+    return page
+  }
+
+  getDataObj(pageId: string, type: 'runtime' | 'static') {
+    const page = this.initPageIfNotExist(pageId)
+    if (type === 'runtime') return page.runtimeData
+    return page.staticData
+  }
+
+  /**
+   * delete all (runtime or static) data of a page
+   */
+  private clearPageData(
+    pageId: string,
+    dataType: 'runtime' | 'static',
+    scheduleUpdate: ScheduleUpdate
+  ) {
+    const dataObj = this.getDataObj(pageId, dataType)
+    Object.values(dataObj).forEach((association) => {
+      association.unBind(scheduleUpdate)
+    })
+  }
+
+  /**
+   * delete all data related to sourceFile
+   */
+  deleteDataAssociatedWithFile(
+    sourceFile: File,
+    scheduleUpdate: ScheduleUpdate
+  ) {
+    sourceFile.associations.forEach((association) => {
+      association.unBind(scheduleUpdate)
+    })
+  }
+}
+
+export interface PagesData {
+  /**
+   * pageId: The page route path.
+   * User can register multiple page data with same pageId,
+   * as long as they have different keys.
+   * Page data with same pageId will be merged.
+   *
+   * @example '/posts/hello-world'
+   */
+  [pageId: string]: {
+    data: {
+      [key: string]: string
+    }
+    staticData: {
+      [key: string]: any
+    }
+  }
+}
+
+interface PagesDataInternal {
+  [pageId: string]: {
+    runtimeData: {
+      /**
+       * The value of runtimeData shoule be a path to module
+       * (to be evaluated at runtime)
+       */
+      [key: string]: Association<string>
+    }
+    staticData: {
+      /**
+       * The value of staticData can be any json value
+       */
+      [key: string]: Association<any>
+    }
+  }
+}
+
+export interface HanlderAPI {
+  getRuntimeData: (
+    pageId: string
+  ) => {
+    [key: string]: string
+  }
+  getStaticData: (
+    pageId: string
+  ) => {
+    [key: string]: any
+  }
+}
+
+export class Association<ValueType = any> {
+  private dataObj: { [key: string]: Association }
+
+  constructor(
+    private pagesDataKeeper: PagesDataKeeper,
+    private pageId: string,
+    private dataType: 'runtime' | 'static',
+    /** the key of this record in the dataObj */
+
+    private key: string,
+    public value: ValueType,
+    /**
+     * when sourceFile is updated (or deleted),
+     * this piece of data shoule also be updated(or deleted)
+     */
+    private sourceFile: File | null,
+    scheduleUpdate: ScheduleUpdate
+  ) {
+    this.dataObj = pagesDataKeeper.getDataObj(pageId, dataType)
+    const existValue = this.dataObj[key]
+    const isEmptyBeforeSet = pagesDataKeeper.isEmptyPage(pageId)
+    // delete exist data and its file association
+    if (existValue) {
+      existValue.unBind(scheduleUpdate)
+    }
+    this.dataObj[key] = this
+    if (sourceFile) sourceFile.associations.add(this)
+    if (isEmptyBeforeSet) {
+      // a new page is added
+      scheduleUpdate({
+        type: 'add',
+        pageId,
+      })
+    } else {
+      scheduleUpdate({
+        type: 'update',
+        pageId,
+      })
+    }
+  }
+
+  /**
+   * delete this piece of data and
+   * unbind its file association
+   */
+  unBind(scheduleUpdate: ScheduleUpdate) {
+    const dataObj = this.pagesDataKeeper.getDataObj(this.pageId, this.dataType)
+    delete dataObj[this.key]
+    if (this.sourceFile) this.sourceFile.associations.delete(this)
+    if (this.pagesDataKeeper.isEmptyPage(this.pageId)) {
+      // the whole page is empty
+      scheduleUpdate({
+        type: 'delete',
+        pageId: this.pageId,
+      })
+    } else {
+      scheduleUpdate({
+        type: 'update',
+        pageId: this.pageId,
+      })
+    }
+  }
+}

--- a/packages/react-pages/src/node/dynamic-modules/PagesData.ts
+++ b/packages/react-pages/src/node/dynamic-modules/PagesData.ts
@@ -14,7 +14,7 @@ export class PagesDataKeeper {
   createAPIForSourceFile(
     sourceFile: File,
     scheduleUpdate: ScheduleUpdate
-  ): HanlderAPI {
+  ): HandlerAPI {
     return {
       getRuntimeData: (
         pageId: string
@@ -35,7 +35,7 @@ export class PagesDataKeeper {
    * If the page page does not come from local file (.e.g from remote database),
    * then we can't track the source of page data.
    */
-  createAPIForCustomSource(scheduleUpdate: ScheduleUpdate): HanlderAPI {
+  createAPIForCustomSource(scheduleUpdate: ScheduleUpdate): HandlerAPI {
     return {
       getRuntimeData: (
         pageId: string
@@ -202,7 +202,7 @@ interface PagesDataInternal {
   }
 }
 
-export interface HanlderAPI {
+export interface HandlerAPI {
   getRuntimeData: (
     pageId: string
   ) => {

--- a/packages/react-pages/src/node/dynamic-modules/PagesData.ts
+++ b/packages/react-pages/src/node/dynamic-modules/PagesData.ts
@@ -259,6 +259,7 @@ export class Association<ValueType = any> {
       scheduleUpdate({
         type: 'update',
         pageId,
+        dataType,
       })
     }
   }
@@ -272,7 +273,7 @@ export class Association<ValueType = any> {
     delete dataObj[this.key]
     if (this.sourceFile) this.sourceFile.associations.delete(this)
     if (this.pagesDataKeeper.isEmptyPage(this.pageId)) {
-      // the whole page is empty
+      // the whole page is empty after deleting this data
       scheduleUpdate({
         type: 'delete',
         pageId: this.pageId,
@@ -281,6 +282,7 @@ export class Association<ValueType = any> {
       scheduleUpdate({
         type: 'update',
         pageId: this.pageId,
+        dataType: this.dataType,
       })
     }
   }

--- a/packages/react-pages/src/node/dynamic-modules/UpdateBuffer.ts
+++ b/packages/react-pages/src/node/dynamic-modules/UpdateBuffer.ts
@@ -50,18 +50,20 @@ export class UpdateBuffer extends EventEmitter {
   constructor() {
     super()
     this.scheduleFlush = debounce(() => {
+      let havePageUpdate = false
       if (this.pageUpdateBuffer.size > 0) {
+        havePageUpdate = true
         const updates = [...this.pageUpdateBuffer.values()]
         this.emit('page', updates)
         this.pageUpdateBuffer.clear()
       }
 
       if (this.pageListUpdateBuffer) {
-        // if this.pageUpdateBuffer.size >= 0
-        // the page update will automatically update the page list
-        // (because the whole import chain will update)
-        // so we don't need to trigger page list update in that case
-        if (this.pageUpdateBuffer.size === 0) this.emit('page-list')
+        // if we have just sent a page update,
+        // we don't need to trigger page list update.
+        // because during the page update hmr, the page list will automatically get updated
+        // (because the whole import chain will get re-imported)
+        if (!havePageUpdate) this.emit('page-list')
         this.pageListUpdateBuffer = false
       }
     }, 100)

--- a/packages/react-pages/src/node/dynamic-modules/UpdateBuffer.ts
+++ b/packages/react-pages/src/node/dynamic-modules/UpdateBuffer.ts
@@ -1,0 +1,105 @@
+import { EventEmitter } from 'events'
+import { debounce } from 'mini-debounce'
+
+/**
+ * Types of page data updates.
+ *
+ * add:
+ *  the page list module will be updated.
+ * update:
+ *  the page list module will be updated.(because static data changed)
+ *  the page data module will be updated.
+ * delete:
+ *  the page list module will be updated.
+ *  buffered update of the deleted page will be cancled.
+ *
+ * TODO: seperate the updates of runtime data and static data
+ * because updates of runtime data don't need to trigger the update of page list module,
+ * and updates of static data don't need to trigger the update of page data module.
+ */
+type Update = {
+  type: 'add' | 'update' | 'delete'
+  pageId: string
+}
+
+export type ScheduleUpdate = (update: Update) => void
+
+/**
+ * Buffer page data updates.
+ * Can flush a batch of updates together
+ * and cancle unnecessary updates
+ */
+export class UpdateBuffer extends EventEmitter {
+  /**
+   * which pages should be updated
+   */
+  private pageUpdateBuffer = new Set<string>()
+
+  /**
+   * whether the page list should be updated
+   */
+  private pageListUpdateBuffer = false
+
+  private scheduleFlush: () => void
+
+  constructor() {
+    super()
+    this.scheduleFlush = debounce(() => {
+      if (this.pageListUpdateBuffer) {
+        this.emit('page-list')
+        this.pageListUpdateBuffer = false
+      }
+
+      if (this.pageUpdateBuffer.size > 0) {
+        const updates = [...this.pageUpdateBuffer.values()]
+        this.emit('page', updates)
+        this.pageUpdateBuffer.clear()
+      }
+    }, 100)
+  }
+
+  scheduleUpdate(update: Update) {
+    switch (update.type) {
+      case 'add':
+        this.pageListUpdateBuffer = true
+        break
+      case 'update':
+        this.pageListUpdateBuffer = true
+        this.pageUpdateBuffer.add(update.pageId)
+        break
+      case 'delete':
+        this.pageListUpdateBuffer = true
+        this.pageUpdateBuffer.delete(update.pageId)
+        break
+      default:
+        throw new Error(`invalid update type ${update.type}`)
+    }
+    this.scheduleFlush()
+  }
+
+  async batchUpdate(exec: (scheduleUpdate: ScheduleUpdate) => Promise<void>) {
+    let updates: Update[] | null = []
+    const _this = this
+
+    try {
+      await exec(scheduleUpdate)
+    } finally {
+      updates.forEach((update) => {
+        _this.scheduleUpdate(update)
+      })
+      updates = null
+      this.scheduleFlush()
+    }
+
+    function scheduleUpdate(update: Update) {
+      if (!updates) {
+        // the batch lifetime has already expired
+        // add it to buffer directly
+        _this.scheduleUpdate(update)
+        return
+      }
+      // store it, will flust these updates together later
+      updates.push(update)
+    }
+  }
+}

--- a/packages/react-pages/src/node/dynamic-modules/UpdateBuffer.ts
+++ b/packages/react-pages/src/node/dynamic-modules/UpdateBuffer.ts
@@ -109,7 +109,7 @@ export class UpdateBuffer extends EventEmitter {
         _this.scheduleUpdate(update)
         return
       }
-      // store it, will flust these updates together later
+      // store it, will flush these updates together later
       updates.push(update)
     }
   }

--- a/packages/react-pages/src/node/dynamic-modules/pages.ts
+++ b/packages/react-pages/src/node/dynamic-modules/pages.ts
@@ -10,12 +10,9 @@ export async function renderPageList(pagesData: PagesData, isBuild: boolean) {
         // so we change the sub path
         subPath = '/__index'
       }
-      const dataProperty = isBuild
-        ? `data = () => import("/@react-pages/pages${subPath}")`
-        : `dataPath = "/@react-pages/pages${subPath}"`
       const code = `
 pages["${pageId}"] = {};
-pages["${pageId}"].${dataProperty};
+pages["${pageId}"].data = () => import("/@react-pages/pages${subPath}");
 pages["${pageId}"].staticData = ${JSON.stringify(staticData)};`
       return code
     }

--- a/packages/react-pages/src/node/dynamic-modules/pages.ts
+++ b/packages/react-pages/src/node/dynamic-modules/pages.ts
@@ -1,5 +1,5 @@
 import slash from 'slash'
-import type { PagesData } from "./PagesData";
+import type { PagesData } from './PagesData'
 
 export async function renderPageList(pagesData: PagesData, isBuild: boolean) {
   const addPagesData = Object.entries(pagesData).map(
@@ -10,10 +10,17 @@ export async function renderPageList(pagesData: PagesData, isBuild: boolean) {
         // so we change the sub path
         subPath = '/__index'
       }
-      const code = `
+      const dataModulePath = `/@react-pages/pages${subPath}`
+      let code = `
 pages["${pageId}"] = {};
-pages["${pageId}"].data = () => import("/@react-pages/pages${subPath}");
+pages["${pageId}"].data = () => import("${dataModulePath}");
 pages["${pageId}"].staticData = ${JSON.stringify(staticData)};`
+      if (!isBuild) {
+        // in dev mode, we provide dataModulePath to let client know
+        // whether the imported module has changed
+        code = `${code}
+pages["${pageId}"].dataModulePath = "${dataModulePath}"`
+      }
       return code
     }
   )

--- a/packages/react-pages/src/node/dynamic-modules/pages.ts
+++ b/packages/react-pages/src/node/dynamic-modules/pages.ts
@@ -1,15 +1,5 @@
 import slash from 'slash'
-
-export interface PagesData {
-  [pageId: string]: {
-    data: {
-      [key: string]: string
-    }
-    staticData: {
-      [key: string]: any
-    }
-  }
-}
+import type { PagesData } from "./PagesData";
 
 export async function renderPageList(pagesData: PagesData, isBuild: boolean) {
   const addPagesData = Object.entries(pagesData).map(

--- a/packages/react-pages/src/node/dynamic-modules/pages.ts
+++ b/packages/react-pages/src/node/dynamic-modules/pages.ts
@@ -15,12 +15,6 @@ export async function renderPageList(pagesData: PagesData, isBuild: boolean) {
 pages["${pageId}"] = {};
 pages["${pageId}"].data = () => import("${dataModulePath}");
 pages["${pageId}"].staticData = ${JSON.stringify(staticData)};`
-      if (!isBuild) {
-        // in dev mode, we provide dataModulePath to let client know
-        // whether the imported module has changed
-        code = `${code}
-pages["${pageId}"].dataModulePath = "${dataModulePath}"`
-      }
       return code
     }
   )

--- a/packages/react-pages/src/node/dynamic-modules/utils.ts
+++ b/packages/react-pages/src/node/dynamic-modules/utils.ts
@@ -1,17 +1,16 @@
 import { extract, parse } from 'jest-docblock'
 import grayMatter from 'gray-matter'
-import { File, FindPages, PageData } from './PageStrategy'
+import { File, FindPages, FileHandler } from './PageStrategy'
 
 export const defaultPageFinder: FindPages = (pagesDir, { watchFiles }) =>
-  watchFiles(pagesDir, '**/*$.{md,mdx,js,jsx,ts,tsx}')
+  watchFiles({ baseDir: pagesDir, globs: '**/*$.{md,mdx,js,jsx,ts,tsx}' })
 
-export const defaultPageLoader = async (file: File): Promise<PageData> => {
+export const defaultFileHandler: FileHandler = async (file: File, api) => {
   const pagePublicPath = getPagePublicPath(file.relative)
-  return {
-    pageId: pagePublicPath,
-    dataPath: file.path,
-    staticData: await extractStaticData(file),
-  }
+  const runtimeData = api.getRuntimeData(pagePublicPath)
+  const staticData = api.getStaticData(pagePublicPath)
+  runtimeData.main = file.path
+  staticData.main = await extractStaticData(file)
 }
 
 export async function extractStaticData(

--- a/packages/react-pages/src/node/dynamic-modules/utils.ts
+++ b/packages/react-pages/src/node/dynamic-modules/utils.ts
@@ -1,17 +1,6 @@
 import { extract, parse } from 'jest-docblock'
 import grayMatter from 'gray-matter'
-import { File, FindPages, FileHandler } from './PageStrategy'
-
-export const defaultPageFinder: FindPages = (pagesDir, { watchFiles }) =>
-  watchFiles({ baseDir: pagesDir, globs: '**/*$.{md,mdx,js,jsx,ts,tsx}' })
-
-export const defaultFileHandler: FileHandler = async (file: File, api) => {
-  const pagePublicPath = getPagePublicPath(file.relative)
-  const runtimeData = api.getRuntimeData(pagePublicPath)
-  const staticData = api.getStaticData(pagePublicPath)
-  runtimeData.main = file.path
-  staticData.main = await extractStaticData(file)
-}
+import { File } from './PageStrategy'
 
 export async function extractStaticData(
   file: File
@@ -29,26 +18,6 @@ export async function extractStaticData(
     default:
       throw new Error(`unexpected extension name "${file.extname}"`)
   }
-}
-
-export function getPagePublicPath(relativePageFilePath: string) {
-  let pagePublicPath = relativePageFilePath.replace(
-    /\$\.(md|mdx|js|jsx|ts|tsx)$/,
-    ''
-  )
-  pagePublicPath = pagePublicPath.replace(/index$/, '')
-  // ensure starting slash
-  pagePublicPath = pagePublicPath.replace(/\/$/, '')
-  pagePublicPath = `/${pagePublicPath}`
-
-  // turn [id] into :id
-  // so that react-router can recognize it as url params
-  pagePublicPath = pagePublicPath.replace(
-    /\[(.*?)\]/g,
-    (_, paramName) => `:${paramName}`
-  )
-
-  return pagePublicPath
 }
 
 /**

--- a/packages/react-pages/src/node/dynamic-modules/utils.ts
+++ b/packages/react-pages/src/node/dynamic-modules/utils.ts
@@ -50,3 +50,33 @@ export function getPagePublicPath(relativePageFilePath: string) {
 
   return pagePublicPath
 }
+
+/**
+ * track how many works are pending
+ * to avoid returning half-finished page data
+ */
+export class PendingList {
+  private pendingCount = 0
+  private subscribers: Array<() => void> = []
+
+  addPending(p: Promise<void>) {
+    this.pendingCount++
+    p.finally(() => {
+      this.pendingCount--
+      if (this.pendingCount === 0) {
+        // all pending works are finished
+        this.subscribers.forEach((notify) => notify())
+        this.subscribers.length = 0
+      }
+    })
+  }
+
+  subscribe(): Promise<void> {
+    if (this.pendingCount === 0) return Promise.resolve()
+    return new Promise((res) => {
+      this.subscribers.push(() => {
+        res()
+      })
+    })
+  }
+}

--- a/packages/react-pages/src/node/index.ts
+++ b/packages/react-pages/src/node/index.ts
@@ -60,7 +60,7 @@ export default function pluginFactory(
       if (opts.pageStrategy) {
         pageStrategy = opts.pageStrategy
       } else {
-        pageStrategy = new DefaultPageStrategy(pagesDir)
+        pageStrategy = new DefaultPageStrategy()
       }
 
       // Inject parsing logic for frontmatter if missing.
@@ -79,7 +79,7 @@ export default function pluginFactory(
         }
       }
 
-      pageStrategy.start()
+      pageStrategy.start(pagesDir)
     },
     configureServer({ watcher, moduleGraph }) {
       const reloadVirtualModule = (moduleId: string) => {

--- a/packages/react-pages/src/node/index.ts
+++ b/packages/react-pages/src/node/index.ts
@@ -62,7 +62,6 @@ export default function pluginFactory(
       } else {
         pageStrategy = new DefaultPageStrategy(pagesDir)
       }
-      pageStrategy.start()
 
       // Inject parsing logic for frontmatter if missing.
       const { devDependencies = {} } = require(path.join(root, 'package.json'))
@@ -79,6 +78,8 @@ export default function pluginFactory(
           )
         }
       }
+
+      pageStrategy.start()
     },
     configureServer({ watcher, moduleGraph }) {
       const reloadVirtualModule = (moduleId: string) => {

--- a/packages/react-pages/src/node/index.ts
+++ b/packages/react-pages/src/node/index.ts
@@ -62,6 +62,7 @@ export default function pluginFactory(
       } else {
         pageStrategy = new DefaultPageStrategy(pagesDir)
       }
+      pageStrategy.start()
 
       // Inject parsing logic for frontmatter if missing.
       const { devDependencies = {} } = require(path.join(root, 'package.json'))

--- a/packages/react-pages/src/node/index.ts
+++ b/packages/react-pages/src/node/index.ts
@@ -36,6 +36,9 @@ export default function pluginFactory(
           '/@pages-infra': path.join(__dirname, '../client/'),
         },
       },
+      optimizeDeps: {
+        include: ['@mdx-js/react'],
+      },
       define: {
         __HASH_ROUTER__: !!useHashRouter,
       },

--- a/packages/react-pages/src/node/index.ts
+++ b/packages/react-pages/src/node/index.ts
@@ -2,11 +2,15 @@ import * as path from 'path'
 import type { Plugin } from 'vite'
 import type { MdxPlugin } from 'vite-plugin-mdx'
 import {
+  DefaultPageStrategy,
+  defaultFileHandler,
+} from './dynamic-modules/DefaultPageStrategy'
+import {
   renderPageList,
   renderPageListInSSR,
   renderOnePageData,
 } from './dynamic-modules/pages'
-import { FindPages, PageStrategy } from './dynamic-modules/PageStrategy'
+import { PageStrategy } from './dynamic-modules/PageStrategy'
 import { resolveTheme } from './dynamic-modules/resolveTheme'
 
 const modulePrefix = '/@react-pages/'
@@ -17,12 +21,12 @@ const ssrDataModuleId = modulePrefix + 'ssrData'
 export default function pluginFactory(
   opts: {
     pagesDir?: string
-    findPages?: FindPages
+    pageStrategy?: PageStrategy
     useHashRouter?: boolean
     staticSiteGeneration?: {}
   } = {}
 ): Plugin {
-  const { findPages, useHashRouter = false, staticSiteGeneration } = opts
+  const { useHashRouter = false, staticSiteGeneration } = opts
 
   let isBuild: boolean
   let pagesDir: string
@@ -53,7 +57,11 @@ export default function pluginFactory(
     configResolved({ root, plugins, logger, command }) {
       isBuild = command === 'build'
       pagesDir = opts.pagesDir ?? path.resolve(root, 'pages')
-      pageStrategy = new PageStrategy(pagesDir, findPages)
+      if (opts.pageStrategy) {
+        pageStrategy = opts.pageStrategy
+      } else {
+        pageStrategy = new DefaultPageStrategy(pagesDir)
+      }
 
       // Inject parsing logic for frontmatter if missing.
       const { devDependencies = {} } = require(path.join(root, 'package.json'))
@@ -129,4 +137,6 @@ export type {
   PagesStaticData,
 } from '../../client'
 
-export { defaultPageFinder, extractStaticData } from './dynamic-modules/utils'
+export { extractStaticData } from './dynamic-modules/utils'
+export { PageStrategy }
+export { DefaultPageStrategy, defaultFileHandler }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,7 +591,7 @@ importers:
       vite: ^2.0.5
 lockfileVersion: 5.2
 overrides:
-  esbuild: 0.8.57
+  esbuild: ^0.9.3
   react: ^17.0.1
   react-dom: ^17.0.1
 packages:
@@ -3340,6 +3340,12 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-j02SFrUwFTRUqiY0Kjplwjm1psuzO1d6AjaXKuOR9hrY0HuPsT6sV42B6myW34h1q4CRy+Y3g4RU/cGJeI/nNA==
+  /esbuild/0.9.7:
+    dev: true
+    hasBin: true
+    requiresBuild: true
+    resolution:
+      integrity: sha512-VtUf6aQ89VTmMLKrWHYG50uByMF4JQlVysb8dmg6cOgW8JnFCipmz7p+HNBl+RR3LLCuBxFGVauAe2wfnF9bLg==
   /escalade/3.1.1:
     engines:
       node: '>=6'
@@ -8647,7 +8653,7 @@ packages:
       integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==
   /vite-plugin-mdx/3.2.2_vite@2.1.4:
     dependencies:
-      esbuild: 0.8.57
+      esbuild: 0.9.7
       find-dependency: 1.3.3
       vite: 2.1.4
     dev: true
@@ -8669,7 +8675,7 @@ packages:
       integrity: sha512-liDo/wxTcy2E5cptwsAUZIC0F4flxWkmcPOJdhKCzJIC9XguWCCJimzziTQRmHuqIPawmQNE8PJb8+RlGzNxOA==
   /vite/2.1.4:
     dependencies:
-      esbuild: 0.8.57
+      esbuild: 0.9.7
       postcss: 8.2.8
       resolve: 1.20.0
       rollup: 2.44.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,6 +591,7 @@ importers:
       vite: ^2.0.5
 lockfileVersion: 5.2
 overrides:
+  esbuild: 0.8.57
   react: ^17.0.1
   react-dom: ^17.0.1
 packages:
@@ -9090,7 +9091,7 @@ packages:
       integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==
   /vite-plugin-mdx/3.2.2_vite@2.0.5:
     dependencies:
-      esbuild: 0.8.50
+      esbuild: 0.8.57
       find-dependency: 1.3.0
       vite: 2.0.5
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,7 @@ importers:
       chokidar: 3.5.1
       dequal: 2.0.2
       enhanced-resolve: 5.7.0
+      fast-deep-equal: 3.1.3
       fs-extra: 9.1.0
       gray-matter: 4.0.2
       jest-docblock: 26.0.0
@@ -497,6 +498,7 @@ importers:
       concurrently: ^6.0.0
       dequal: ^2.0.2
       enhanced-resolve: ^5.7.0
+      fast-deep-equal: ^3.1.3
       fs-extra: ^9.1.0
       gray-matter: ^4.0.2
       jest-docblock: ^26.0.0
@@ -3951,7 +3953,6 @@ packages:
     resolution:
       integrity: sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
   /fast-deep-equal/3.1.3:
-    dev: true
     resolution:
       integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
   /fast-glob/3.2.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,14 +1,14 @@
 importers:
   .:
     devDependencies:
-      '@pnpm/link-bins': 5.3.24
-      '@types/jest': 26.0.20
-      '@types/node': 14.14.34
+      '@pnpm/link-bins': 5.3.25
+      '@types/jest': 26.0.22
+      '@types/node': 14.14.37
       jest: 26.6.3
       playwright-chromium: 1.9.2
       sirv: 1.0.11
       slash: 3.0.0
-      ts-jest: 26.5.3_jest@26.6.3+typescript@4.2.3
+      ts-jest: 26.5.4_jest@26.6.3+typescript@4.2.3
       typescript: 4.2.3
       vite-pages-theme-basic: link:packages/theme-basic
     specifiers:
@@ -16,7 +16,7 @@ importers:
       '@types/jest': ^26.0.19
       '@types/node': ^14.14.34
       jest: ^26.6.3
-      playwright-chromium: ^1.7.0
+      playwright-chromium: ~1.9.2
       sirv: ^1.0.10
       slash: ^3.0.0
       ts-jest: ^26.4.4
@@ -24,9 +24,9 @@ importers:
       vite-pages-theme-basic: workspace:*
   doc-site:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
       vite-pages-theme-basic: link:../packages/theme-basic
     devDependencies:
       '@types/react': 17.0.3
@@ -34,7 +34,7 @@ importers:
       '@vitejs/plugin-react-refresh': 1.3.1
       gh-pages: 3.1.0
       serve: 11.3.2
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../packages/vite-plugin-mdx
       vite-plugin-react-pages: link:../packages/react-pages
     specifiers:
@@ -52,22 +52,22 @@ importers:
       vite-plugin-react-pages: workspace:*
   fixtures/analyze-source-code:
     dependencies:
-      '@mdx-js/react': 1.6.22_react@17.0.1
+      '@mdx-js/react': 1.6.22_react@17.0.2
       '@pika/react': 16.13.1
-      '@pika/react-dom': 16.13.1_react@17.0.1
-      react-live: 2.2.3_react-dom@17.0.1+react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      '@pika/react-dom': 16.13.1_react@17.0.2
+      react-live: 2.2.3_react-dom@17.0.2+react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
     devDependencies:
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
-      antd: 4.14.0_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      antd: 4.15.0_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       sass: 1.32.8
       serve: 11.3.2
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../packages/vite-plugin-mdx
-      vite-plugin-react: 4.0.1_vite@2.0.5
+      vite-plugin-react: 4.0.1_vite@2.1.4
       vite-plugin-react-pages: link:../../packages/react-pages
     specifiers:
       '@mdx-js/react': ^1.6.22
@@ -88,15 +88,15 @@ importers:
       vite-plugin-react-pages: workspace:*
   fixtures/basic:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
     devDependencies:
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
       '@vitejs/plugin-react-refresh': 1.3.1
       sass: 1.32.8
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../packages/vite-plugin-mdx
       vite-plugin-react-pages: link:../../packages/react-pages
     specifiers:
@@ -112,17 +112,17 @@ importers:
       vite-plugin-react-pages: workspace:*
   fixtures/custom-find-pages:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
       vite-pages-theme-basic: link:../../packages/theme-basic
     devDependencies:
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
       '@vitejs/plugin-react-refresh': 1.3.1
-      globby: 11.0.2
+      globby: 11.0.3
       serve: 11.3.2
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../packages/vite-plugin-mdx
       vite-plugin-react-pages: link:../../packages/react-pages
     specifiers:
@@ -141,7 +141,7 @@ importers:
   fixtures/library:
     devDependencies:
       '@types/react': 17.0.3
-      react: 17.0.1
+      react: 17.0.2
       typescript: 4.2.3
     specifiers:
       '@types/react': ^17.0.3
@@ -149,18 +149,18 @@ importers:
       typescript: ^4.2.3
   fixtures/library-demos:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
       vite-pages-theme-basic: link:../../packages/theme-basic
     devDependencies:
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
       '@vitejs/plugin-react-refresh': 1.3.1
-      globby: 11.0.2
+      globby: 11.0.3
       my-lib: link:../library
       serve: 11.3.2
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../packages/vite-plugin-mdx
       vite-plugin-react-pages: link:../../packages/react-pages
     specifiers:
@@ -179,12 +179,12 @@ importers:
       vite-plugin-react-pages: workspace:*
   fixtures/mdx-basic:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      styled-components: 5.2.1_react-dom@17.0.1+react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      styled-components: 5.2.2_react-dom@17.0.2+react@17.0.2
     devDependencies:
       '@vitejs/plugin-react-refresh': 1.3.1
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../packages/vite-plugin-mdx
     specifiers:
       '@vitejs/plugin-react-refresh': ^1.3.1
@@ -195,13 +195,13 @@ importers:
       vite-plugin-mdx: workspace:^2.0.1
   fixtures/mdx-plugin:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@vitejs/plugin-react-refresh': 1.3.1
       remark-slug: 6.0.0
       remark-toc: 7.2.0
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../packages/vite-plugin-mdx
     specifiers:
       '@vitejs/plugin-react-refresh': ^1.3.1
@@ -213,16 +213,16 @@ importers:
       vite-plugin-mdx: workspace:^2.0.1
   fixtures/use-theme:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
       vite-pages-theme-basic: link:../../packages/theme-basic
     devDependencies:
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
       '@vitejs/plugin-react-refresh': 1.3.1
       serve: 11.3.2
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../packages/vite-plugin-mdx
       vite-plugin-react-pages: link:../../packages/react-pages
     specifiers:
@@ -246,19 +246,19 @@ importers:
       minimist: ^1.2.5
   packages/create-project/template-app:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
       vite-pages-theme-basic: link:../../theme-basic
     devDependencies:
-      '@types/node': 14.14.34
+      '@types/node': 14.14.37
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
       '@vitejs/plugin-react-refresh': 1.3.1
       sass: 1.32.8
       serve: 11.3.2
-      vite: 2.0.5
-      vite-plugin-mdx: 3.2.2_vite@2.0.5
+      vite: 2.1.4
+      vite-plugin-mdx: 3.2.2_vite@2.1.4
       vite-plugin-react-pages: link:../../react-pages
     specifiers:
       '@types/node': ^14.14.34
@@ -276,18 +276,18 @@ importers:
       vite-plugin-react-pages: workspace:^2.1.0
   packages/create-project/template-lib:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
       vite-pages-theme-basic: link:../../theme-basic
     devDependencies:
-      '@types/node': 14.14.34
+      '@types/node': 14.14.37
       '@types/react': 17.0.3
       '@vitejs/plugin-react-refresh': 1.3.1
       serve: 11.3.2
       typescript: 4.2.3
-      vite: 2.0.5
-      vite-plugin-mdx: 3.2.2_vite@2.0.5
+      vite: 2.1.4
+      vite-plugin-mdx: 3.2.2_vite@2.1.4
       vite-plugin-react-pages: link:../../react-pages
     specifiers:
       '@types/node': ^14.14.34
@@ -307,7 +307,7 @@ importers:
   packages/create-project/template-lib-monorepo/packages/button:
     devDependencies:
       '@types/react': 17.0.3
-      react: 17.0.1
+      react: 17.0.2
       typescript: 4.2.3
     specifiers:
       '@types/react': ^17.0.3
@@ -316,7 +316,7 @@ importers:
   packages/create-project/template-lib-monorepo/packages/card:
     devDependencies:
       '@types/react': 17.0.3
-      react: 17.0.1
+      react: 17.0.2
       typescript: 4.2.3
     specifiers:
       '@types/react': ^17.0.3
@@ -324,20 +324,20 @@ importers:
       typescript: ^4.2.3
   packages/create-project/template-lib-monorepo/packages/demos:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
       vite-pages-theme-basic: link:../../../../theme-basic
     devDependencies:
-      '@types/node': 14.14.34
+      '@types/node': 14.14.37
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
       '@vitejs/plugin-react-refresh': 1.3.1
-      globby: 11.0.2
+      globby: 11.0.3
       my-button: link:../button
       my-card: link:../card
       serve: 11.3.2
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../../../vite-plugin-mdx
       vite-plugin-react-pages: link:../../../../react-pages
     specifiers:
@@ -363,15 +363,15 @@ importers:
       css-color-names: ^1.0.1
   packages/playground/basic:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
     devDependencies:
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
       '@vitejs/plugin-react-refresh': 1.3.1
       sass: 1.32.8
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../vite-plugin-mdx
       vite-plugin-react-pages: link:../../react-pages
     specifiers:
@@ -387,17 +387,17 @@ importers:
       vite-plugin-react-pages: workspace:*
   packages/playground/custom-find-pages:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
       vite-pages-theme-basic: link:../../theme-basic
     devDependencies:
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
       '@vitejs/plugin-react-refresh': 1.3.1
-      globby: 11.0.2
+      globby: 11.0.3
       serve: 11.3.2
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../vite-plugin-mdx
       vite-plugin-react-pages: link:../../react-pages
     specifiers:
@@ -415,8 +415,8 @@ importers:
       vite-plugin-react-pages: workspace:*
   packages/playground/react:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@vitejs/plugin-react-refresh': 1.3.1
     specifiers:
@@ -425,16 +425,16 @@ importers:
       react-dom: ^17.0.1
   packages/playground/use-theme:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-router-dom: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.2.0_react@17.0.2
       vite-pages-theme-basic: link:../../theme-basic
     devDependencies:
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
       '@vitejs/plugin-react-refresh': 1.3.1
       serve: 11.3.2
-      vite: 2.0.5
+      vite: 2.1.4
       vite-plugin-mdx: link:../../vite-plugin-mdx
       vite-plugin-react-pages: link:../../react-pages
     specifiers:
@@ -451,9 +451,9 @@ importers:
       vite-plugin-react-pages: workspace:*
   packages/react-pages:
     dependencies:
-      '@babel/preset-react': 7.12.13
+      '@babel/preset-react': 7.13.13
       '@babel/preset-typescript': 7.13.0
-      '@rollup/plugin-babel': 5.3.0_rollup@2.41.2
+      '@rollup/plugin-babel': 5.3.0_rollup@2.44.0
       chalk: 4.1.0
       chokidar: 3.5.1
       dequal: 2.0.2
@@ -462,27 +462,27 @@ importers:
       fs-extra: 9.1.0
       gray-matter: 4.0.2
       jest-docblock: 26.0.0
-      jotai: 0.15.3_react@17.0.1
+      jotai: 0.15.5_react@17.0.2
       mini-debounce: 1.0.8
       minimist: 1.2.5
       read-pkg-up: 7.0.1
       remark-frontmatter: 2.0.0
-      rollup: 2.41.2
+      rollup: 2.44.0
       rollup-plugin-postcss: 4.0.0
       slash: 3.0.0
       tiny-invariant: 1.1.0
     devDependencies:
       '@types/enhanced-resolve': 3.0.6
-      '@types/fs-extra': 9.0.8
+      '@types/fs-extra': 9.0.9
       '@types/minimist': 1.2.1
       '@types/react': 17.0.3
-      '@types/react-dom': 17.0.2
+      '@types/react-dom': 17.0.3
       '@types/react-router-dom': 5.1.7
       concurrently: 6.0.0
-      react: 17.0.1
+      react: 17.0.2
       typescript: 4.2.3
-      vite: 2.0.5
-      vite-plugin-mdx: 3.2.2_vite@2.0.5
+      vite: 2.1.4
+      vite-plugin-mdx: 3.2.2_vite@2.1.4
     specifiers:
       '@babel/preset-react': ^7.12.13
       '@babel/preset-typescript': ^7.13.0
@@ -519,14 +519,14 @@ importers:
     dependencies:
       github-markdown-css: 4.0.0
     devDependencies:
-      '@alifd/next': 1.22.11_react@17.0.1
-      '@babel/preset-react': 7.12.13
+      '@alifd/next': 1.22.16_react@17.0.2
+      '@babel/preset-react': 7.13.13
       '@babel/preset-typescript': 7.13.0
-      '@mdx-js/react': 1.6.22_react@17.0.1
-      '@rollup/plugin-babel': 5.3.0_rollup@2.41.2
-      '@rollup/plugin-commonjs': 17.1.0_rollup@2.41.2
-      '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.2
-      '@rollup/plugin-typescript': 8.2.0_rollup@2.41.2+typescript@4.2.3
+      '@mdx-js/react': 1.6.22_react@17.0.2
+      '@rollup/plugin-babel': 5.3.0_rollup@2.44.0
+      '@rollup/plugin-commonjs': 17.1.0_rollup@2.44.0
+      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.44.0
+      '@rollup/plugin-typescript': 8.2.1_rollup@2.44.0+typescript@4.2.3
       '@types/mdx-js__react': 1.5.3
       '@types/react': 17.0.3
       '@types/react-router-dom': 5.1.7
@@ -535,10 +535,10 @@ importers:
       chokidar: 3.5.1
       concurrently: 6.0.0
       fs-extra: 9.1.0
-      globby: 11.0.2
-      prism-react-renderer: 1.2.0_react@17.0.1
-      react: 17.0.1
-      rollup: 2.41.2
+      globby: 11.0.3
+      prism-react-renderer: 1.2.0_react@17.0.2
+      react: 17.0.2
+      rollup: 2.44.0
       rollup-plugin-postcss: 4.0.0
       typescript: 4.2.3
       vite-plugin-react-pages: link:../react-pages
@@ -569,16 +569,16 @@ importers:
       vite-plugin-react-pages: workspace:*
   packages/vite-plugin-mdx:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.13.10
+      '@babel/core': 7.13.14
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.13.14
       '@mdx-js/mdx': 1.6.22
       '@mdx-js/react': 1.6.22
       react-refresh: 0.9.0
       remark-frontmatter: 2.0.0
     devDependencies:
-      esbuild: 0.8.50
+      esbuild: 0.8.57
       typescript: 4.2.3
-      vite: 2.0.5
+      vite: 2.1.4
     specifiers:
       '@babel/core': ^7.13.10
       '@babel/plugin-syntax-import-meta': ^7.10.4
@@ -602,7 +602,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-xIAm9f0Fh+TbuBasJ5StJPfh2BxIwT9QTs5JoGN41rW8/+RhxhVV1b70vnepb4+YRMAQrDnFEE6uWBDZTSOJIA==
-  /@alifd/next/1.22.11_react@17.0.1:
+  /@alifd/next/1.22.16_react@17.0.2:
     dependencies:
       '@alifd/field': 1.4.6
       '@alifd/validate': 1.2.1
@@ -612,9 +612,9 @@ packages:
       hoist-non-react-statics: 2.5.5
       lodash.clonedeep: 4.5.0
       prop-types: 15.7.2
-      react: 17.0.1
+      react: 17.0.2
       react-lifecycles-compat: 3.0.4
-      react-transition-group: 2.9.0_react@17.0.1
+      react-transition-group: 2.9.0_react@17.0.2
       resize-observer-polyfill: 1.5.1
       shallow-element-equals: 1.0.1
     dev: true
@@ -624,7 +624,7 @@ packages:
       react: ^16.0.0
       react-dom: ^16.0.0
     resolution:
-      integrity: sha512-s/l9q9PprFLpUF1l6FMVykrGYaVKeoW/Kywa80FDt4OD9cSfDO6hpaCP/YR8j1hHyKoLxz/gydJm8Wop5yqbgw==
+      integrity: sha512-yoG86+Y6sNvn9SuK3tFbhHMBLpZYBjRLCkPY62bPjCfqZSCVT90142xC+TcSg2mmDjUz81vxCaeM8DAUGGAMDw==
   /@alifd/validate/1.2.1:
     dev: true
     resolution:
@@ -639,15 +639,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ==
-  /@ant-design/icons/4.5.0_react-dom@17.0.1+react@17.0.1:
+  /@ant-design/icons/4.6.2_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@ant-design/colors': 6.0.0
       '@ant-design/icons-svg': 4.1.0
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      insert-css: 2.0.0
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
     dev: true
     engines:
       node: '>=8'
@@ -655,7 +654,7 @@ packages:
       react: '>=16.0.0'
       react-dom: '*'
     resolution:
-      integrity: sha512-ZAKJcmr4DBV3NWr8wm2dCxNKN4eFrX+qCaPsuFejP6FRsf+m5OKxvCVi9bSp1lmKWeOI5yECAx5s0uFm4QHuPw==
+      integrity: sha512-QsBG2BxBYU/rxr2eb8b2cZ4rPKAPBpzAR+0v6rrZLp/lnyvflLH3tw1vregK+M7aJauGWjIGNdFmUfpAOtw25A==
   /@ant-design/react-slick/0.28.2:
     dependencies:
       '@babel/runtime': 7.13.10
@@ -666,85 +665,30 @@ packages:
     dev: true
     resolution:
       integrity: sha512-nkrvXsO29pLToFaBb3MlJY4McaUFR4UHtXTz6A5HBzYmxH4SwKerX54mWdGc/6tKpHvS3vUwjEOt2T5XqZEo8Q==
-  /@babel/code-frame/7.10.4:
-    dependencies:
-      '@babel/highlight': 7.10.4
-    resolution:
-      integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
-  /@babel/code-frame/7.12.11:
-    dependencies:
-      '@babel/highlight': 7.10.4
-    resolution:
-      integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
   /@babel/code-frame/7.12.13:
     dependencies:
-      '@babel/highlight': 7.12.13
+      '@babel/highlight': 7.13.10
     resolution:
       integrity: sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
-  /@babel/compat-data/7.13.8:
-    dev: false
+  /@babel/compat-data/7.13.12:
     resolution:
-      integrity: sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==
-  /@babel/core/7.12.10:
-    dependencies:
-      '@babel/code-frame': 7.10.4
-      '@babel/generator': 7.12.11
-      '@babel/helper-module-transforms': 7.12.1
-      '@babel/helpers': 7.12.5
-      '@babel/parser': 7.12.11
-      '@babel/template': 7.12.7
-      '@babel/traverse': 7.12.12
-      '@babel/types': 7.12.12
-      convert-source-map: 1.7.0
-      debug: 4.3.1
-      gensync: 1.0.0-beta.2
-      json5: 2.1.3
-      lodash: 4.17.20
-      semver: 5.7.1
-      source-map: 0.5.7
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==
-  /@babel/core/7.12.17:
+      integrity: sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==
+  /@babel/core/7.12.9:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@babel/generator': 7.12.17
-      '@babel/helper-module-transforms': 7.12.17
-      '@babel/helpers': 7.12.17
-      '@babel/parser': 7.12.17
+      '@babel/generator': 7.13.9
+      '@babel/helper-module-transforms': 7.13.14
+      '@babel/helpers': 7.13.10
+      '@babel/parser': 7.13.13
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.12.17
-      '@babel/types': 7.12.17
+      '@babel/traverse': 7.13.13
+      '@babel/types': 7.13.14
       convert-source-map: 1.7.0
       debug: 4.3.1
       gensync: 1.0.0-beta.2
       json5: 2.2.0
       lodash: 4.17.21
-      semver: 5.7.1
-      source-map: 0.5.7
-    dev: true
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-V3CuX1aBywbJvV2yzJScRxeiiw0v2KZZYYE3giywxzFJL13RiyPjaaDwhDnxmgFTTS7FgvM2ijr4QmKNIu0AtQ==
-  /@babel/core/7.12.9:
-    dependencies:
-      '@babel/code-frame': 7.12.11
-      '@babel/generator': 7.12.11
-      '@babel/helper-module-transforms': 7.12.1
-      '@babel/helpers': 7.12.5
-      '@babel/parser': 7.12.11
-      '@babel/template': 7.12.7
-      '@babel/traverse': 7.12.12
-      '@babel/types': 7.12.12
-      convert-source-map: 1.7.0
-      debug: 4.3.1
-      gensync: 1.0.0-beta.2
-      json5: 2.1.3
-      lodash: 4.17.20
-      resolve: 1.19.0
+      resolve: 1.20.0
       semver: 5.7.1
       source-map: 0.5.7
     dev: false
@@ -752,408 +696,201 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==
-  /@babel/core/7.13.10:
+  /@babel/core/7.13.14:
     dependencies:
       '@babel/code-frame': 7.12.13
       '@babel/generator': 7.13.9
-      '@babel/helper-compilation-targets': 7.13.10_@babel+core@7.13.10
-      '@babel/helper-module-transforms': 7.13.0
+      '@babel/helper-compilation-targets': 7.13.13_@babel+core@7.13.14
+      '@babel/helper-module-transforms': 7.13.14
       '@babel/helpers': 7.13.10
-      '@babel/parser': 7.13.10
+      '@babel/parser': 7.13.13
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
+      '@babel/traverse': 7.13.13
+      '@babel/types': 7.13.14
       convert-source-map: 1.7.0
       debug: 4.3.1
       gensync: 1.0.0-beta.2
       json5: 2.2.0
-      lodash: 4.17.21
       semver: 6.3.0
       source-map: 0.5.7
-    dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==
-  /@babel/generator/7.12.11:
-    dependencies:
-      '@babel/types': 7.12.12
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    resolution:
-      integrity: sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==
-  /@babel/generator/7.12.17:
-    dependencies:
-      '@babel/types': 7.12.17
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    dev: true
-    resolution:
-      integrity: sha512-DSA7ruZrY4WI8VxuS1jWSRezFnghEoYEFrZcw9BizQRmOZiUsiHl59+qEARGPqPikwA/GPTyRCi7isuCK/oyqg==
-  /@babel/generator/7.12.5:
-    dependencies:
-      '@babel/types': 7.12.7
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    dev: false
-    resolution:
-      integrity: sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==
+      integrity: sha512-wZso/vyF4ki0l0znlgM4inxbdrUvCb+cVz8grxDq+6C9k6qbqoIJteQOKicaKjCipU3ISV+XedCqpL2RJJVehA==
   /@babel/generator/7.13.9:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
       jsesc: 2.5.2
       source-map: 0.5.7
     resolution:
       integrity: sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
-  /@babel/helper-annotate-as-pure/7.10.4:
-    dependencies:
-      '@babel/types': 7.12.7
-    dev: false
-    resolution:
-      integrity: sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
   /@babel/helper-annotate-as-pure/7.12.13:
     dependencies:
-      '@babel/types': 7.12.17
+      '@babel/types': 7.13.14
     resolution:
       integrity: sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==
-  /@babel/helper-compilation-targets/7.13.10_@babel+core@7.13.10:
+  /@babel/helper-compilation-targets/7.13.13_@babel+core@7.13.14:
     dependencies:
-      '@babel/compat-data': 7.13.8
-      '@babel/core': 7.13.10
+      '@babel/compat-data': 7.13.12
+      '@babel/core': 7.13.14
       '@babel/helper-validator-option': 7.12.17
       browserslist: 4.16.3
       semver: 6.3.0
-    dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==
-  /@babel/helper-create-class-features-plugin/7.13.10:
+      integrity: sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==
+  /@babel/helper-create-class-features-plugin/7.13.11:
     dependencies:
       '@babel/helper-function-name': 7.12.13
-      '@babel/helper-member-expression-to-functions': 7.13.0
+      '@babel/helper-member-expression-to-functions': 7.13.12
       '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-replace-supers': 7.13.0
+      '@babel/helper-replace-supers': 7.13.12
       '@babel/helper-split-export-declaration': 7.12.13
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-YV7r2YxdTUaw84EwNkyrRke/TJHR/UXGiyvACRqvdVJ2/syV2rQuJNnaRLSuYiop8cMRXOgseTGoJCWX0q2fFg==
-  /@babel/helper-function-name/7.10.4:
-    dependencies:
-      '@babel/helper-get-function-arity': 7.10.4
-      '@babel/template': 7.12.7
-      '@babel/types': 7.12.7
-    dev: false
-    resolution:
-      integrity: sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
-  /@babel/helper-function-name/7.12.11:
-    dependencies:
-      '@babel/helper-get-function-arity': 7.12.10
-      '@babel/template': 7.12.7
-      '@babel/types': 7.12.12
-    resolution:
-      integrity: sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==
+      integrity: sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==
   /@babel/helper-function-name/7.12.13:
     dependencies:
       '@babel/helper-get-function-arity': 7.12.13
       '@babel/template': 7.12.13
-      '@babel/types': 7.12.17
+      '@babel/types': 7.13.14
     resolution:
       integrity: sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
-  /@babel/helper-get-function-arity/7.10.4:
-    dependencies:
-      '@babel/types': 7.12.7
-    dev: false
-    resolution:
-      integrity: sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
-  /@babel/helper-get-function-arity/7.12.10:
-    dependencies:
-      '@babel/types': 7.12.12
-    resolution:
-      integrity: sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==
   /@babel/helper-get-function-arity/7.12.13:
     dependencies:
-      '@babel/types': 7.12.17
+      '@babel/types': 7.13.14
     resolution:
       integrity: sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
-  /@babel/helper-member-expression-to-functions/7.12.17:
+  /@babel/helper-member-expression-to-functions/7.13.12:
     dependencies:
-      '@babel/types': 7.12.17
-    dev: true
+      '@babel/types': 7.13.14
     resolution:
-      integrity: sha512-Bzv4p3ODgS/qpBE0DiJ9qf5WxSmrQ8gVTe8ClMfwwsY2x/rhykxxy3bXzG7AGTnPB2ij37zGJ/Q/6FruxHxsxg==
-  /@babel/helper-member-expression-to-functions/7.12.7:
+      integrity: sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==
+  /@babel/helper-module-imports/7.13.12:
     dependencies:
-      '@babel/types': 7.12.12
+      '@babel/types': 7.13.14
     resolution:
-      integrity: sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==
-  /@babel/helper-member-expression-to-functions/7.13.0:
+      integrity: sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
+  /@babel/helper-module-transforms/7.13.14:
     dependencies:
-      '@babel/types': 7.13.0
-    resolution:
-      integrity: sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==
-  /@babel/helper-module-imports/7.12.13:
-    dependencies:
-      '@babel/types': 7.12.17
-    resolution:
-      integrity: sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
-  /@babel/helper-module-imports/7.12.5:
-    dependencies:
-      '@babel/types': 7.12.7
-    resolution:
-      integrity: sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
-  /@babel/helper-module-transforms/7.12.1:
-    dependencies:
-      '@babel/helper-module-imports': 7.12.5
-      '@babel/helper-replace-supers': 7.12.5
-      '@babel/helper-simple-access': 7.12.1
-      '@babel/helper-split-export-declaration': 7.12.11
-      '@babel/helper-validator-identifier': 7.12.11
-      '@babel/template': 7.12.7
-      '@babel/traverse': 7.12.12
-      '@babel/types': 7.12.12
-      lodash: 4.17.20
-    resolution:
-      integrity: sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==
-  /@babel/helper-module-transforms/7.12.17:
-    dependencies:
-      '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-replace-supers': 7.12.13
-      '@babel/helper-simple-access': 7.12.13
+      '@babel/helper-module-imports': 7.13.12
+      '@babel/helper-replace-supers': 7.13.12
+      '@babel/helper-simple-access': 7.13.12
       '@babel/helper-split-export-declaration': 7.12.13
       '@babel/helper-validator-identifier': 7.12.11
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.12.17
-      '@babel/types': 7.12.17
-      lodash: 4.17.21
-    dev: true
+      '@babel/traverse': 7.13.13
+      '@babel/types': 7.13.14
     resolution:
-      integrity: sha512-sFL+p6zOCQMm9vilo06M4VHuTxUAwa6IxgL56Tq1DVtA0ziAGTH1ThmJq7xwPqdQlgAbKX3fb0oZNbtRIyA5KQ==
-  /@babel/helper-module-transforms/7.13.0:
-    dependencies:
-      '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-replace-supers': 7.13.0
-      '@babel/helper-simple-access': 7.12.13
-      '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/helper-validator-identifier': 7.12.11
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
-      lodash: 4.17.21
-    dev: false
-    resolution:
-      integrity: sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==
+      integrity: sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==
   /@babel/helper-optimise-call-expression/7.12.13:
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.14
     resolution:
       integrity: sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
-  /@babel/helper-optimise-call-expression/7.12.7:
-    dependencies:
-      '@babel/types': 7.12.7
-    resolution:
-      integrity: sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==
   /@babel/helper-plugin-utils/7.10.4:
+    dev: false
     resolution:
       integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
-  /@babel/helper-plugin-utils/7.12.13:
-    resolution:
-      integrity: sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==
   /@babel/helper-plugin-utils/7.13.0:
     resolution:
       integrity: sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
-  /@babel/helper-replace-supers/7.12.13:
+  /@babel/helper-replace-supers/7.13.12:
     dependencies:
-      '@babel/helper-member-expression-to-functions': 7.12.17
+      '@babel/helper-member-expression-to-functions': 7.13.12
       '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/traverse': 7.12.17
-      '@babel/types': 7.12.17
-    dev: true
+      '@babel/traverse': 7.13.13
+      '@babel/types': 7.13.14
     resolution:
-      integrity: sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==
-  /@babel/helper-replace-supers/7.12.5:
+      integrity: sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==
+  /@babel/helper-simple-access/7.13.12:
     dependencies:
-      '@babel/helper-member-expression-to-functions': 7.12.7
-      '@babel/helper-optimise-call-expression': 7.12.7
-      '@babel/traverse': 7.12.12
-      '@babel/types': 7.12.12
+      '@babel/types': 7.13.14
     resolution:
-      integrity: sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==
-  /@babel/helper-replace-supers/7.13.0:
-    dependencies:
-      '@babel/helper-member-expression-to-functions': 7.13.0
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
-    resolution:
-      integrity: sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==
-  /@babel/helper-simple-access/7.12.1:
-    dependencies:
-      '@babel/types': 7.12.12
-    resolution:
-      integrity: sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==
-  /@babel/helper-simple-access/7.12.13:
-    dependencies:
-      '@babel/types': 7.13.0
-    resolution:
-      integrity: sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==
-  /@babel/helper-split-export-declaration/7.11.0:
-    dependencies:
-      '@babel/types': 7.12.7
-    dev: false
-    resolution:
-      integrity: sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==
-  /@babel/helper-split-export-declaration/7.12.11:
-    dependencies:
-      '@babel/types': 7.12.12
-    resolution:
-      integrity: sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==
+      integrity: sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   /@babel/helper-split-export-declaration/7.12.13:
     dependencies:
-      '@babel/types': 7.12.17
+      '@babel/types': 7.13.14
     resolution:
       integrity: sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
-  /@babel/helper-validator-identifier/7.10.4:
-    resolution:
-      integrity: sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
   /@babel/helper-validator-identifier/7.12.11:
     resolution:
       integrity: sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
   /@babel/helper-validator-option/7.12.17:
     resolution:
       integrity: sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
-  /@babel/helpers/7.12.17:
-    dependencies:
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.12.17
-      '@babel/types': 7.12.17
-    dev: true
-    resolution:
-      integrity: sha512-tEpjqSBGt/SFEsFikKds1sLNChKKGGR17flIgQKXH4fG6m9gTgl3gnOC1giHNyaBCSKuTfxaSzHi7UnvqiVKxg==
-  /@babel/helpers/7.12.5:
-    dependencies:
-      '@babel/template': 7.12.7
-      '@babel/traverse': 7.12.12
-      '@babel/types': 7.12.12
-    resolution:
-      integrity: sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==
   /@babel/helpers/7.13.10:
     dependencies:
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
-    dev: false
+      '@babel/traverse': 7.13.13
+      '@babel/types': 7.13.14
     resolution:
       integrity: sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==
-  /@babel/highlight/7.10.4:
-    dependencies:
-      '@babel/helper-validator-identifier': 7.10.4
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    resolution:
-      integrity: sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
-  /@babel/highlight/7.12.13:
+  /@babel/highlight/7.13.10:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
       chalk: 2.4.2
       js-tokens: 4.0.0
     resolution:
-      integrity: sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
-  /@babel/parser/7.12.11:
+      integrity: sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
+  /@babel/parser/7.13.13:
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
-  /@babel/parser/7.12.17:
-    engines:
-      node: '>=6.0.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-r1yKkiUTYMQ8LiEI0UcQx5ETw5dpTLn9wijn9hk6KkTtOK95FndDN10M+8/s6k/Ymlbivw0Av9q4SlgF80PtHg==
-  /@babel/parser/7.12.7:
-    dev: false
-    engines:
-      node: '>=6.0.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==
-  /@babel/parser/7.13.10:
-    engines:
-      node: '>=6.0.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==
+      integrity: sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==
   /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.9:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.9
-      '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.12.9
+      '@babel/plugin-transform-parameters': 7.13.0_@babel+core@7.12.9
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.12.17:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.12.17:
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.12.17:
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.12.10:
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.10
-      '@babel/helper-plugin-utils': 7.10.4
-    dev: true
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.12.17:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.10.4
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.13.10:
-    dependencies:
-      '@babel/core': 7.13.10
-      '@babel/helper-plugin-utils': 7.10.4
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.12.17:
-    dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1161,7 +898,7 @@ packages:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   /@babel/plugin-syntax-jsx/7.12.13:
     dependencies:
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/helper-plugin-utils': 7.13.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -1169,79 +906,79 @@ packages:
   /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.12.9:
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.12.17:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.12.17:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.12.17:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.17:
-    dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.10.4
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.9:
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.12.17:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.13.14:
+    dependencies:
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.12.17:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-top-level-await/7.12.13_@babel+core@7.12.17:
+  /@babel/plugin-syntax-top-level-await/7.12.13_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1254,86 +991,87 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==
-  /@babel/plugin-transform-parameters/7.12.1_@babel+core@7.12.9:
+  /@babel/plugin-transform-parameters/7.13.0_@babel+core@7.12.9:
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==
+      integrity: sha512-Jt8k/h/mIwE2JFEOb3lURoY5C85ETcYPnbuAJ96zRBzh1XHtQZfs62ChZ6EP22QlC8c7Xqr9q+e1SU5qttwwjw==
   /@babel/plugin-transform-react-display-name/7.12.13:
     dependencies:
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/helper-plugin-utils': 7.13.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MprESJzI9O5VnJZrL7gg1MpdqmiFcUv41Jc7SahxYsNP2kDkFqClxxTZq+1Qv4AFCamm+GXMRDQINNn+qrxmiA==
   /@babel/plugin-transform-react-jsx-development/7.12.17:
     dependencies:
-      '@babel/plugin-transform-react-jsx': 7.12.17
+      '@babel/plugin-transform-react-jsx': 7.13.12
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-BPjYV86SVuOaudFhsJR1zjgxxOhJDt6JHNoD48DxWEIxUCAMjV1ys6DYw4SDYZh0b1QsS2vfIA9t/ZsQGsDOUQ==
-  /@babel/plugin-transform-react-jsx-self/7.12.13_@babel+core@7.12.17:
+  /@babel/plugin-transform-react-jsx-self/7.12.13_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-FXYw98TTJ125GVCCkFLZXlZ1qGcsYqNQhVBQcZjyrwf8FEUtVfKIoidnO8S0q+KBQpDYNTmiGo1gn67Vti04lQ==
-  /@babel/plugin-transform-react-jsx-source/7.12.13_@babel+core@7.12.17:
+  /@babel/plugin-transform-react-jsx-source/7.12.13_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/core': 7.13.14
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-O5JJi6fyfih0WfDgIJXksSPhGP/G0fQpfxYy87sDc+1sFmsCS6wr3aAn+whbzkhbjtq4VMqLRaSzR6IsshIC0Q==
-  /@babel/plugin-transform-react-jsx/7.12.17:
+  /@babel/plugin-transform-react-jsx/7.13.12:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/helper-module-imports': 7.13.12
+      '@babel/helper-plugin-utils': 7.13.0
       '@babel/plugin-syntax-jsx': 7.12.13
-      '@babel/types': 7.12.17
+      '@babel/types': 7.13.14
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-mwaVNcXV+l6qJOuRhpdTEj8sT/Z0owAVWf9QujTZ0d2ye9X/K+MTOTSizcgKOj18PGnTc/7g1I4+cIUjsKhBcw==
+      integrity: sha512-jcEI2UqIcpCqB5U5DRxIl0tQEProI2gcu+g8VTIqxLO5Iidojb4d77q+fwGseCvd8af/lJ9masp4QWzBXFE2xA==
   /@babel/plugin-transform-react-pure-annotations/7.12.1:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/helper-plugin-utils': 7.13.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==
   /@babel/plugin-transform-typescript/7.13.0:
     dependencies:
-      '@babel/helper-create-class-features-plugin': 7.13.10
+      '@babel/helper-create-class-features-plugin': 7.13.11
       '@babel/helper-plugin-utils': 7.13.0
       '@babel/plugin-syntax-typescript': 7.12.13
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-elQEwluzaU8R8dbVuW2Q2Y8Nznf7hnjM7+DSCd14Lo5fF63C9qNLbwZYbmZrtV9/ySpSUpkRpQXvJb6xyu4hCQ==
-  /@babel/preset-react/7.12.13:
+  /@babel/preset-react/7.13.13:
     dependencies:
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/helper-plugin-utils': 7.13.0
+      '@babel/helper-validator-option': 7.12.17
       '@babel/plugin-transform-react-display-name': 7.12.13
-      '@babel/plugin-transform-react-jsx': 7.12.17
+      '@babel/plugin-transform-react-jsx': 7.13.12
       '@babel/plugin-transform-react-jsx-development': 7.12.17
       '@babel/plugin-transform-react-pure-annotations': 7.12.1
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-TYM0V9z6Abb6dj1K7i5NrEhA13oS5ujUYQYDfqIBXYHOc2c2VkFgc+q9kyssIyUfy4/hEwqrgSlJ/Qgv8zJLsA==
+      integrity: sha512-gx+tDLIE06sRjKJkVtpZ/t3mzCDOnPG+ggHZG9lffUbX8+wC739x20YQc9V35Do6ZAxaUc/HhVHIiOzz5MvDmA==
   /@babel/preset-typescript/7.13.0:
     dependencies:
       '@babel/helper-plugin-utils': 7.13.0
@@ -1343,129 +1081,59 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-LXJwxrHy0N3f6gIJlYbLta1D9BDtHpQeqwzM0LIfjDlr6UE/D5Mc7W4iDiQzaE+ks0sTjT26ArcHWnJVt0QiHw==
-  /@babel/runtime/7.10.5:
-    dependencies:
-      regenerator-runtime: 0.13.7
-    dev: false
-    resolution:
-      integrity: sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
-  /@babel/runtime/7.12.5:
-    dependencies:
-      regenerator-runtime: 0.13.7
-    dev: true
-    resolution:
-      integrity: sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   /@babel/runtime/7.13.10:
     dependencies:
       regenerator-runtime: 0.13.7
-    dev: true
     resolution:
       integrity: sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
   /@babel/template/7.12.13:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@babel/parser': 7.12.17
-      '@babel/types': 7.12.17
+      '@babel/parser': 7.13.13
+      '@babel/types': 7.13.14
     resolution:
       integrity: sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
-  /@babel/template/7.12.7:
-    dependencies:
-      '@babel/code-frame': 7.12.11
-      '@babel/parser': 7.12.11
-      '@babel/types': 7.12.12
-    resolution:
-      integrity: sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==
-  /@babel/traverse/7.12.12:
-    dependencies:
-      '@babel/code-frame': 7.12.11
-      '@babel/generator': 7.12.11
-      '@babel/helper-function-name': 7.12.11
-      '@babel/helper-split-export-declaration': 7.12.11
-      '@babel/parser': 7.12.11
-      '@babel/types': 7.12.12
-      debug: 4.3.1
-      globals: 11.12.0
-      lodash: 4.17.20
-    resolution:
-      integrity: sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==
-  /@babel/traverse/7.12.17:
-    dependencies:
-      '@babel/code-frame': 7.12.13
-      '@babel/generator': 7.12.17
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/parser': 7.12.17
-      '@babel/types': 7.12.17
-      debug: 4.3.1
-      globals: 11.12.0
-      lodash: 4.17.21
-    dev: true
-    resolution:
-      integrity: sha512-LGkTqDqdiwC6Q7fWSwQoas/oyiEYw6Hqjve5KOSykXkmFJFqzvGMb9niaUEag3Rlve492Mkye3gLw9FTv94fdQ==
-  /@babel/traverse/7.12.7_supports-color@5.5.0:
-    dependencies:
-      '@babel/code-frame': 7.10.4
-      '@babel/generator': 7.12.5
-      '@babel/helper-function-name': 7.10.4
-      '@babel/helper-split-export-declaration': 7.11.0
-      '@babel/parser': 7.12.7
-      '@babel/types': 7.12.7
-      debug: 4.3.1_supports-color@5.5.0
-      globals: 11.12.0
-      lodash: 4.17.20
-    dev: false
-    peerDependencies:
-      supports-color: '*'
-    resolution:
-      integrity: sha512-nMWaqsQEeSvMNypswUDzjqQ+0rR6pqCtoQpsqGJC4/Khm9cISwPTSpai57F6/jDaOoEGz8yE/WxcO3PV6tKSmQ==
-  /@babel/traverse/7.13.0:
+  /@babel/traverse/7.13.13:
     dependencies:
       '@babel/code-frame': 7.12.13
       '@babel/generator': 7.13.9
       '@babel/helper-function-name': 7.12.13
       '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/parser': 7.13.10
-      '@babel/types': 7.13.0
+      '@babel/parser': 7.13.13
+      '@babel/types': 7.13.14
       debug: 4.3.1
       globals: 11.12.0
-      lodash: 4.17.21
     resolution:
-      integrity: sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==
-  /@babel/types/7.12.12:
+      integrity: sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==
+  /@babel/traverse/7.13.13_supports-color@5.5.0:
     dependencies:
-      '@babel/helper-validator-identifier': 7.12.11
-      lodash: 4.17.20
-      to-fast-properties: 2.0.0
+      '@babel/code-frame': 7.12.13
+      '@babel/generator': 7.13.9
+      '@babel/helper-function-name': 7.12.13
+      '@babel/helper-split-export-declaration': 7.12.13
+      '@babel/parser': 7.13.13
+      '@babel/types': 7.13.14
+      debug: 4.3.1_supports-color@5.5.0
+      globals: 11.12.0
+    dev: false
+    peerDependencies:
+      supports-color: '*'
     resolution:
-      integrity: sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
-  /@babel/types/7.12.17:
-    dependencies:
-      '@babel/helper-validator-identifier': 7.12.11
-      lodash: 4.17.21
-      to-fast-properties: 2.0.0
-    resolution:
-      integrity: sha512-tNMDjcv/4DIcHxErTgwB9q2ZcYyN0sUfgGKUK/mm1FJK7Wz+KstoEekxrl/tBiNDgLK1HGi+sppj1An/1DR4fQ==
-  /@babel/types/7.12.7:
-    dependencies:
-      '@babel/helper-validator-identifier': 7.10.4
-      lodash: 4.17.20
-      to-fast-properties: 2.0.0
-    resolution:
-      integrity: sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==
-  /@babel/types/7.13.0:
+      integrity: sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==
+  /@babel/types/7.13.14:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
       lodash: 4.17.21
       to-fast-properties: 2.0.0
     resolution:
-      integrity: sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==
+      integrity: sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==
   /@bcoe/v8-coverage/0.2.3:
     dev: true
     resolution:
       integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
   /@cnakazawa/watch/1.0.4:
     dependencies:
-      exec-sh: 0.3.4
+      exec-sh: 0.3.6
       minimist: 1.2.5
     dev: true
     engines:
@@ -1518,7 +1186,7 @@ packages:
   /@jest/console/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       chalk: 4.1.0
       jest-message-util: 26.6.2
       jest-util: 26.6.2
@@ -1535,8 +1203,8 @@ packages:
       '@jest/test-result': 26.6.2
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.31
-      ansi-escapes: 4.3.1
+      '@types/node': 14.14.37
+      ansi-escapes: 4.3.2
       chalk: 4.1.0
       exit: 0.1.2
       graceful-fs: 4.2.6
@@ -1567,7 +1235,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       jest-mock: 26.6.2
     dev: true
     engines:
@@ -1578,7 +1246,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@sinonjs/fake-timers': 6.0.1
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       jest-message-util: 26.6.2
       jest-mock: 26.6.2
       jest-util: 26.6.2
@@ -1620,9 +1288,9 @@ packages:
       jest-worker: 26.6.2
       slash: 3.0.0
       source-map: 0.6.1
-      string-length: 4.0.1
+      string-length: 4.0.2
       terminal-link: 2.1.1
-      v8-to-istanbul: 7.1.0
+      v8-to-istanbul: 7.1.1
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -1665,7 +1333,7 @@ packages:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/transform/26.6.2:
     dependencies:
-      '@babel/core': 7.12.17
+      '@babel/core': 7.13.14
       '@jest/types': 26.6.2
       babel-plugin-istanbul: 6.0.0
       chalk: 4.1.0
@@ -1689,7 +1357,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.0
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       '@types/yargs': 15.0.13
       chalk: 4.1.0
     dev: true
@@ -1727,9 +1395,9 @@ packages:
       react: ^16.13.1 || ^17.0.0
     resolution:
       integrity: sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==
-  /@mdx-js/react/1.6.22_react@17.0.1:
+  /@mdx-js/react/1.6.22_react@17.0.2:
     dependencies:
-      react: 17.0.1
+      react: 17.0.2
     peerDependencies:
       react: ^16.13.1 || ^17.0.0
     resolution:
@@ -1741,7 +1409,7 @@ packages:
   /@nodelib/fs.scandir/2.1.4:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
-      run-parallel: 1.1.10
+      run-parallel: 1.2.0
     dev: true
     engines:
       node: '>= 8'
@@ -1756,15 +1424,15 @@ packages:
   /@nodelib/fs.walk/1.2.6:
     dependencies:
       '@nodelib/fs.scandir': 2.1.4
-      fastq: 1.10.0
+      fastq: 1.11.0
     dev: true
     engines:
       node: '>= 8'
     resolution:
       integrity: sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
-  /@pika/react-dom/16.13.1_react@17.0.1:
+  /@pika/react-dom/16.13.1_react@17.0.2:
     dependencies:
-      react: 17.0.1
+      react: 17.0.2
     dev: false
     peerDependencies:
       react: ^16.0.0
@@ -1780,12 +1448,12 @@ packages:
       node: '>=10.16'
     resolution:
       integrity: sha512-vxkRrkneBPVmP23kyjnYwVOtipwlSl6UfL+h+Xa3TrABJTz5rYBXemlTsU5BzST8U4pD7YDkTb3SQu+MMuIDKA==
-  /@pnpm/link-bins/5.3.24:
+  /@pnpm/link-bins/5.3.25:
     dependencies:
       '@pnpm/error': 1.4.0
-      '@pnpm/package-bins': 4.0.11
+      '@pnpm/package-bins': 4.1.0
       '@pnpm/read-modules-dir': 2.0.3
-      '@pnpm/read-package-json': 3.1.9
+      '@pnpm/read-package-json': 4.0.0
       '@pnpm/read-project-manifest': 1.1.7
       '@pnpm/types': 6.4.0
       '@zkochan/cmd-shim': 5.1.0
@@ -1799,18 +1467,17 @@ packages:
     engines:
       node: '>=10.16'
     resolution:
-      integrity: sha512-JPJG9EBBhqtl42+9KnKVpEGoD2OtIC2JwqyvgKMCY2apfvXIr449hwv4SeFXBaLWjt3mXuB+XPikzodEYabrvA==
-  /@pnpm/package-bins/4.0.11:
+      integrity: sha512-9Xq8lLNRHFDqvYPXPgaiKkZ4rtdsm7izwM/cUsFDc5IMnG0QYIVBXQbgwhz2UvjUotbJrvfKLJaCfA3NGBnLDg==
+  /@pnpm/package-bins/4.1.0:
     dependencies:
       '@pnpm/types': 6.4.0
-      graceful-fs: 4.2.4
+      fast-glob: 3.2.5
       is-subdir: 1.2.0
-      p-filter: 2.1.0
     dev: true
     engines:
       node: '>=10.16'
     resolution:
-      integrity: sha512-EzpdzuUX+2tDL65Rm83aVAfqeD+Fywzfr5u3ng9CMaDDxGt48QZOiIAoLgM9+dNBF2ebChFBUofTwOhgT9Dj2Q==
+      integrity: sha512-57/ioGYLBbVRR80Ux9/q2i3y8Q+uQADc3c+Yse8jr/60YLOi3jcWz13e2Jy+ANYtZI258Qc5wk2X077rp0Ly/Q==
   /@pnpm/read-modules-dir/2.0.3:
     dependencies:
       mz: 2.7.0
@@ -1819,16 +1486,17 @@ packages:
       node: '>=10.13'
     resolution:
       integrity: sha512-i9OgRvSlxrTS9a2oXokhDxvQzDtfqtsooJ9jaGoHkznue5aFCTSrNZFQ6M18o8hC03QWfnxaKi0BtOvNkKu2+A==
-  /@pnpm/read-package-json/3.1.9:
+  /@pnpm/read-package-json/4.0.0:
     dependencies:
       '@pnpm/error': 1.4.0
       '@pnpm/types': 6.4.0
-      read-package-json: 3.0.1
+      load-json-file: 6.2.0
+      normalize-package-data: 3.0.2
     dev: true
     engines:
       node: '>=10.16'
     resolution:
-      integrity: sha512-5Zad2JR2ekNJCAYrHYDZUv+RHLUUxG5z6zV+Ycooo3yhLcr3+tssjHPJAelkMABGUon/2fDZcdNcyz1jP4fMFA==
+      integrity: sha512-1cr2tEwe4YU6SI0Hmg+wnsr6yxBt2iJtqv6wrF84On8pS9hx4A2PLw3CIgbwxaG0b+ur5wzhNogwl4qD5FLFNg==
   /@pnpm/read-project-manifest/1.1.7:
     dependencies:
       '@pnpm/error': 1.4.0
@@ -1866,15 +1534,15 @@ packages:
       node: '>=10.16'
     resolution:
       integrity: sha512-OLkDZSqkA1mkoPNPvLFXyI6fb0enCuFji6Zfditi/CLAo9kmIhQFmEUDu4krSB8i908EljG8YwL5Xjxzm5wsWA==
-  /@polka/url/1.0.0-next.11:
+  /@polka/url/1.0.0-next.12:
     dev: true
     resolution:
-      integrity: sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
-  /@rollup/plugin-babel/5.3.0_rollup@2.41.2:
+      integrity: sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ==
+  /@rollup/plugin-babel/5.3.0_rollup@2.44.0:
     dependencies:
-      '@babel/helper-module-imports': 7.12.13
-      '@rollup/pluginutils': 3.1.0_rollup@2.41.2
-      rollup: 2.41.2
+      '@babel/helper-module-imports': 7.13.12
+      '@rollup/pluginutils': 3.1.0_rollup@2.44.0
+      rollup: 2.44.0
     engines:
       node: '>= 10.0.0'
     peerDependencies:
@@ -1886,16 +1554,16 @@ packages:
         optional: true
     resolution:
       integrity: sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==
-  /@rollup/plugin-commonjs/17.1.0_rollup@2.41.2:
+  /@rollup/plugin-commonjs/17.1.0_rollup@2.44.0:
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.41.2
+      '@rollup/pluginutils': 3.1.0_rollup@2.44.0
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.1.6
       is-reference: 1.2.1
       magic-string: 0.25.7
       resolve: 1.20.0
-      rollup: 2.41.2
+      rollup: 2.44.0
     dev: true
     engines:
       node: '>= 8.0.0'
@@ -1903,27 +1571,27 @@ packages:
       rollup: ^2.30.0
     resolution:
       integrity: sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==
-  /@rollup/plugin-node-resolve/11.2.0_rollup@2.41.2:
+  /@rollup/plugin-node-resolve/11.2.1_rollup@2.44.0:
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.41.2
+      '@rollup/pluginutils': 3.1.0_rollup@2.44.0
       '@types/resolve': 1.17.1
       builtin-modules: 3.2.0
       deepmerge: 4.2.2
       is-module: 1.0.0
       resolve: 1.20.0
-      rollup: 2.41.2
+      rollup: 2.44.0
     dev: true
     engines:
       node: '>= 10.0.0'
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     resolution:
-      integrity: sha512-qHjNIKYt5pCcn+5RUBQxK8krhRvf1HnyVgUCcFFcweDS7fhkOLZeYh0mhHK6Ery8/bb9tvN/ubPzmfF0qjDCTA==
-  /@rollup/plugin-typescript/8.2.0_rollup@2.41.2+typescript@4.2.3:
+      integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==
+  /@rollup/plugin-typescript/8.2.1_rollup@2.44.0+typescript@4.2.3:
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.41.2
+      '@rollup/pluginutils': 3.1.0_rollup@2.44.0
       resolve: 1.20.0
-      rollup: 2.41.2
+      rollup: 2.44.0
       typescript: 4.2.3
     dev: true
     engines:
@@ -1931,15 +1599,15 @@ packages:
     peerDependencies:
       rollup: ^2.14.0
       tslib: '*'
-      typescript: '>=3.4.0'
+      typescript: '>=3.7.0'
     resolution:
-      integrity: sha512-5DyVsb7L+ehLfNPu/nat8Gq3uJGzku4bMFPt90XahtgiSBf7z9YKPLqFUJKMT41W/mJ98SVGDPOhzikGrr/Lhg==
-  /@rollup/pluginutils/3.1.0_rollup@2.41.2:
+      integrity: sha512-Qd2E1pleDR4bwyFxqbjt4eJf+wB0UKVMLc7/BAFDGVdAXQMCsD4DUv5/7/ww47BZCYxWtJqe1Lo0KVNswBJlRw==
+  /@rollup/pluginutils/3.1.0_rollup@2.44.0:
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.2.2
-      rollup: 2.41.2
+      rollup: 2.44.0
     engines:
       node: '>= 8.0.0'
     peerDependencies:
@@ -1958,38 +1626,38 @@ packages:
     dev: true
     resolution:
       integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
-  /@types/babel__core/7.1.12:
+  /@types/babel__core/7.1.14:
     dependencies:
-      '@babel/parser': 7.12.17
-      '@babel/types': 7.12.17
+      '@babel/parser': 7.13.13
+      '@babel/types': 7.13.14
       '@types/babel__generator': 7.6.2
       '@types/babel__template': 7.4.0
       '@types/babel__traverse': 7.11.1
     dev: true
     resolution:
-      integrity: sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==
+      integrity: sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==
   /@types/babel__generator/7.6.2:
     dependencies:
-      '@babel/types': 7.12.17
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==
   /@types/babel__template/7.4.0:
     dependencies:
-      '@babel/parser': 7.12.17
-      '@babel/types': 7.12.17
+      '@babel/parser': 7.13.13
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==
   /@types/babel__traverse/7.11.1:
     dependencies:
-      '@babel/types': 7.12.17
+      '@babel/types': 7.13.14
     dev: true
     resolution:
       integrity: sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==
   /@types/enhanced-resolve/3.0.6:
     dependencies:
-      '@types/node': 14.0.23
+      '@types/node': 14.14.37
       '@types/tapable': 0.2.5
     dev: true
     resolution:
@@ -1997,19 +1665,19 @@ packages:
   /@types/estree/0.0.39:
     resolution:
       integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
-  /@types/estree/0.0.46:
+  /@types/estree/0.0.47:
     dev: true
     resolution:
-      integrity: sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
-  /@types/fs-extra/9.0.8:
+      integrity: sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
+  /@types/fs-extra/9.0.9:
     dependencies:
-      '@types/node': 14.14.34
+      '@types/node': 14.14.37
     dev: true
     resolution:
-      integrity: sha512-bnlTVTwq03Na7DpWxFJ1dvnORob+Otb8xHyUqUWhqvz/Ksg8+JXPlR52oeMSZ37YEOa5PyccbgUNutiQdi13TA==
+      integrity: sha512-5TqDycCl0oMzwzd1cIjSJWMKMvLCDVErle4ZTjU4EmHDURR/+yZghe6GDHMCpHtcVfq0x0gMoOM546/5TbYHrg==
   /@types/graceful-fs/4.1.5:
     dependencies:
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
     dev: true
     resolution:
       integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
@@ -2039,13 +1707,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
-  /@types/jest/26.0.20:
+  /@types/jest/26.0.22:
     dependencies:
       jest-diff: 26.6.2
       pretty-format: 26.6.2
     dev: true
     resolution:
-      integrity: sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+      integrity: sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==
   /@types/mdast/3.0.3:
     dependencies:
       '@types/unist': 2.0.3
@@ -2053,7 +1721,7 @@ packages:
       integrity: sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==
   /@types/mdx-js__react/1.5.3:
     dependencies:
-      '@types/react': 17.0.0
+      '@types/react': 17.0.3
     dev: true
     resolution:
       integrity: sha512-flP0BpS5rXnEbkU5ih79ARaI/+rK10Iee+zxTaWYtoiyc2+f1EJ8EnYgMmXHdAuI7OX4J9/hdoXfrfrri0AT+Q==
@@ -2061,18 +1729,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
-  /@types/node/14.0.23:
+  /@types/node/14.14.37:
     dev: true
     resolution:
-      integrity: sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==
-  /@types/node/14.14.31:
-    dev: true
-    resolution:
-      integrity: sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==
-  /@types/node/14.14.34:
-    dev: true
-    resolution:
-      integrity: sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
+      integrity: sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
   /@types/normalize-package-data/2.4.0:
     resolution:
       integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
@@ -2083,10 +1743,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
-  /@types/prettier/2.2.2:
+  /@types/prettier/2.2.3:
     dev: true
     resolution:
-      integrity: sha512-i99hy7Ki19EqVOl77WplDrvgNugHnsSjECVR/wUrzw2TJXz1zlUfT2ngGckR6xN7yFYaijsMAqPkOLx9HgUqHg==
+      integrity: sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
   /@types/prop-types/15.7.3:
     dev: true
     resolution:
@@ -2094,34 +1754,27 @@ packages:
   /@types/q/1.5.4:
     resolution:
       integrity: sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
-  /@types/react-dom/17.0.2:
+  /@types/react-dom/17.0.3:
     dependencies:
       '@types/react': 17.0.3
     dev: true
     resolution:
-      integrity: sha512-Icd9KEgdnFfJs39KyRyr0jQ7EKhq8U6CcHRMGAS45fp5qgUvxL3ujUCfWFttUK2UErqZNj97t9gsVPNAqcwoCg==
+      integrity: sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==
   /@types/react-router-dom/5.1.7:
     dependencies:
       '@types/history': 4.7.8
-      '@types/react': 17.0.0
-      '@types/react-router': 5.1.9
+      '@types/react': 17.0.3
+      '@types/react-router': 5.1.13
     dev: true
     resolution:
       integrity: sha512-D5mHD6TbdV/DNHYsnwBTv+y73ei+mMjrkGrla86HthE4/PVvL1J94Bu3qABU+COXzpL23T1EZapVVpwHuBXiUg==
-  /@types/react-router/5.1.9:
+  /@types/react-router/5.1.13:
     dependencies:
       '@types/history': 4.7.8
-      '@types/react': 17.0.0
+      '@types/react': 17.0.3
     dev: true
     resolution:
-      integrity: sha512-US6C0rq2Wt/7uje1roqO0R++Sr0jqplKaBChDY5sNg5k7GC/79YFK0ZsLEdemqUjW05wq1Y/9YYEUgfNZ8TlvA==
-  /@types/react/17.0.0:
-    dependencies:
-      '@types/prop-types': 15.7.3
-      csstype: 3.0.5
-    dev: true
-    resolution:
-      integrity: sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
+      integrity: sha512-ZIuaO9Yrln54X6elg8q2Ivp6iK6p4syPsefEYAhRDAoqNh48C8VYUmB9RkXjKSQAJSJV0mbIFCX7I4vZDcHrjg==
   /@types/react/17.0.3:
     dependencies:
       '@types/prop-types': 15.7.3
@@ -2132,7 +1785,7 @@ packages:
       integrity: sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
   /@types/resolve/1.17.1:
     dependencies:
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
     dev: true
     resolution:
       integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
@@ -2163,16 +1816,16 @@ packages:
       integrity: sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
   /@types/yauzl/2.9.1:
     dependencies:
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
     dev: true
     optional: true
     resolution:
       integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
   /@vitejs/plugin-react-refresh/1.3.1:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/plugin-transform-react-jsx-self': 7.12.13_@babel+core@7.12.17
-      '@babel/plugin-transform-react-jsx-source': 7.12.13_@babel+core@7.12.17
+      '@babel/core': 7.13.14
+      '@babel/plugin-transform-react-jsx-self': 7.12.13_@babel+core@7.13.14
+      '@babel/plugin-transform-react-jsx-source': 7.12.13_@babel+core@7.13.14
       react-refresh: 0.9.0
     dev: true
     engines:
@@ -2197,7 +1850,7 @@ packages:
       integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
   /accepts/1.3.7:
     dependencies:
-      mime-types: 2.1.27
+      mime-types: 2.1.29
       negotiator: 0.6.2
     dev: true
     engines:
@@ -2244,7 +1897,7 @@ packages:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
-      uri-js: 4.2.2
+      uri-js: 4.4.1
     dev: true
     resolution:
       integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -2253,7 +1906,7 @@ packages:
       fast-deep-equal: 2.0.1
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
-      uri-js: 4.2.2
+      uri-js: 4.4.1
     dev: true
     resolution:
       integrity: sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==
@@ -2266,14 +1919,14 @@ packages:
     dev: true
     resolution:
       integrity: sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=
-  /ansi-escapes/4.3.1:
+  /ansi-escapes/4.3.2:
     dependencies:
-      type-fest: 0.11.0
+      type-fest: 0.21.3
     dev: true
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
+      integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
   /ansi-regex/3.0.0:
     dev: true
     engines:
@@ -2300,10 +1953,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
-  /antd/4.14.0_react-dom@17.0.1+react@17.0.1:
+  /antd/4.15.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@ant-design/colors': 6.0.0
-      '@ant-design/icons': 4.5.0_react-dom@17.0.1+react@17.0.1
+      '@ant-design/icons': 4.6.2_react-dom@17.0.2+react@17.0.2
       '@ant-design/react-slick': 0.28.2
       '@babel/runtime': 7.13.10
       array-tree-filter: 2.1.0
@@ -2311,47 +1964,47 @@ packages:
       copy-to-clipboard: 3.3.1
       lodash: 4.17.21
       moment: 2.29.1
-      rc-cascader: 1.4.2_react-dom@17.0.1+react@17.0.1
-      rc-checkbox: 2.3.2_react-dom@17.0.1+react@17.0.1
-      rc-collapse: 3.1.0_react-dom@17.0.1+react@17.0.1
-      rc-dialog: 8.5.2_react-dom@17.0.1+react@17.0.1
-      rc-drawer: 4.3.1_react-dom@17.0.1+react@17.0.1
-      rc-dropdown: 3.2.0_react-dom@17.0.1+react@17.0.1
-      rc-field-form: 1.20.0_react-dom@17.0.1+react@17.0.1
-      rc-image: 5.2.3_react-dom@17.0.1+react@17.0.1
-      rc-input-number: 7.0.2_react-dom@17.0.1+react@17.0.1
-      rc-mentions: 1.5.3_react-dom@17.0.1+react@17.0.1
-      rc-menu: 8.10.6_react-dom@17.0.1+react@17.0.1
-      rc-motion: 2.4.1_react-dom@17.0.1+react@17.0.1
-      rc-notification: 4.5.5_react-dom@17.0.1+react@17.0.1
-      rc-pagination: 3.1.6_react-dom@17.0.1+react@17.0.1
-      rc-picker: 2.5.10_react-dom@17.0.1+react@17.0.1
-      rc-progress: 3.1.3_react-dom@17.0.1+react@17.0.1
-      rc-rate: 2.9.1_react-dom@17.0.1+react@17.0.1
-      rc-resize-observer: 1.0.0_react-dom@17.0.1+react@17.0.1
-      rc-select: 12.1.6_react-dom@17.0.1+react@17.0.1
-      rc-slider: 9.7.1_react-dom@17.0.1+react@17.0.1
-      rc-steps: 4.1.3_react-dom@17.0.1+react@17.0.1
-      rc-switch: 3.2.2_react-dom@17.0.1+react@17.0.1
-      rc-table: 7.13.2_react-dom@17.0.1+react@17.0.1
-      rc-tabs: 11.7.3_react-dom@17.0.1+react@17.0.1
-      rc-textarea: 0.3.4_react-dom@17.0.1+react@17.0.1
-      rc-tooltip: 5.1.0_react-dom@17.0.1+react@17.0.1
-      rc-tree: 4.1.5_react-dom@17.0.1+react@17.0.1
-      rc-tree-select: 4.3.0_react-dom@17.0.1+react@17.0.1
-      rc-trigger: 5.2.3_react-dom@17.0.1+react@17.0.1
-      rc-upload: 4.2.0-alpha.0_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      scroll-into-view-if-needed: 2.2.27
+      rc-cascader: 1.4.2_react-dom@17.0.2+react@17.0.2
+      rc-checkbox: 2.3.2_react-dom@17.0.2+react@17.0.2
+      rc-collapse: 3.1.0_react-dom@17.0.2+react@17.0.2
+      rc-dialog: 8.5.2_react-dom@17.0.2+react@17.0.2
+      rc-drawer: 4.3.1_react-dom@17.0.2+react@17.0.2
+      rc-dropdown: 3.2.0_react-dom@17.0.2+react@17.0.2
+      rc-field-form: 1.20.0_react-dom@17.0.2+react@17.0.2
+      rc-image: 5.2.4_react-dom@17.0.2+react@17.0.2
+      rc-input-number: 7.0.3_react-dom@17.0.2+react@17.0.2
+      rc-mentions: 1.5.3_react-dom@17.0.2+react@17.0.2
+      rc-menu: 8.10.7_react-dom@17.0.2+react@17.0.2
+      rc-motion: 2.4.1_react-dom@17.0.2+react@17.0.2
+      rc-notification: 4.5.5_react-dom@17.0.2+react@17.0.2
+      rc-pagination: 3.1.6_react-dom@17.0.2+react@17.0.2
+      rc-picker: 2.5.10_react-dom@17.0.2+react@17.0.2
+      rc-progress: 3.1.3_react-dom@17.0.2+react@17.0.2
+      rc-rate: 2.9.1_react-dom@17.0.2+react@17.0.2
+      rc-resize-observer: 1.0.0_react-dom@17.0.2+react@17.0.2
+      rc-select: 12.1.7_react-dom@17.0.2+react@17.0.2
+      rc-slider: 9.7.2_react-dom@17.0.2+react@17.0.2
+      rc-steps: 4.1.3_react-dom@17.0.2+react@17.0.2
+      rc-switch: 3.2.2_react-dom@17.0.2+react@17.0.2
+      rc-table: 7.13.3_react-dom@17.0.2+react@17.0.2
+      rc-tabs: 11.7.3_react-dom@17.0.2+react@17.0.2
+      rc-textarea: 0.3.4_react-dom@17.0.2+react@17.0.2
+      rc-tooltip: 5.1.0_react-dom@17.0.2+react@17.0.2
+      rc-tree: 4.1.5_react-dom@17.0.2+react@17.0.2
+      rc-tree-select: 4.3.1_react-dom@17.0.2+react@17.0.2
+      rc-trigger: 5.2.3_react-dom@17.0.2+react@17.0.2
+      rc-upload: 4.2.0_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      scroll-into-view-if-needed: 2.2.28
       warning: 4.0.3
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
-      integrity: sha512-K0VG6Ion4gGX8Lo8mJVfNDD8JrHjTq/qlBkicmpZGQXOOAWi19EElH2RpKGN1+WD4OXekWo6dZkSDmK2Lzxe5Q==
+      integrity: sha512-24HMixmQAhCyqb0ND5wX5DYRTbPactCT36mfVKowqgr77eT7XQ59Uu6aS513mbeiVhXcHrNlrlCKNZBSeEDgPg==
   /any-promise/1.3.0:
     dev: true
     resolution:
@@ -2371,10 +2024,10 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
-  /arch/2.1.2:
+  /arch/2.2.0:
     dev: true
     resolution:
-      integrity: sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==
+      integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
   /arg/2.0.0:
     dev: true
     resolution:
@@ -2460,7 +2113,7 @@ packages:
       integrity: sha512-DDmKA7sdSAJtTVeNZHrnr2yojfFaoeW8MfQN8CeuXg8DDQHTqKk9Fdv38dSvnesHoO8MUwMI2HphOeSyIF+wmQ==
   /async/2.6.3:
     dependencies:
-      lodash: 4.17.19
+      lodash: 4.17.21
     dev: true
     resolution:
       integrity: sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -2488,14 +2141,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
-  /babel-jest/26.6.3_@babel+core@7.12.17:
+  /babel-jest/26.6.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
+      '@babel/core': 7.13.14
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
-      '@types/babel__core': 7.1.12
+      '@types/babel__core': 7.1.14
       babel-plugin-istanbul: 6.0.0
-      babel-preset-jest: 26.6.2_@babel+core@7.12.17
+      babel-preset-jest: 26.6.2_@babel+core@7.13.14
       chalk: 4.1.0
       graceful-fs: 4.2.6
       slash: 3.0.0
@@ -2524,14 +2177,14 @@ packages:
       integrity: sha512-yJ9BsJaISua7d8zNT7oRG1ZLBJCIdZ4PZqmH8qa9N5AK01ifk3fnkc98AXhtzE7UkfCsEumvoQWgoYLhOnJ7jQ==
   /babel-plugin-import/1.13.3:
     dependencies:
-      '@babel/helper-module-imports': 7.12.5
-      '@babel/runtime': 7.12.5
+      '@babel/helper-module-imports': 7.13.12
+      '@babel/runtime': 7.13.10
     dev: true
     resolution:
       integrity: sha512-1qCWdljJOrDRH/ybaCZuDgySii4yYrtQ8OJQwrcDqdt0y67N30ng3X3nABg6j7gR7qUJgcMa9OMhc4AGViDwWw==
   /babel-plugin-istanbul/6.0.0:
     dependencies:
-      '@babel/helper-plugin-utils': 7.12.13
+      '@babel/helper-plugin-utils': 7.13.0
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 4.0.3
@@ -2544,21 +2197,21 @@ packages:
   /babel-plugin-jest-hoist/26.6.2:
     dependencies:
       '@babel/template': 7.12.13
-      '@babel/types': 7.12.17
-      '@types/babel__core': 7.1.12
+      '@babel/types': 7.13.14
+      '@types/babel__core': 7.1.14
       '@types/babel__traverse': 7.11.1
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==
-  /babel-plugin-styled-components/1.12.0_styled-components@5.2.1:
+  /babel-plugin-styled-components/1.12.0_styled-components@5.2.2:
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-annotate-as-pure': 7.12.13
+      '@babel/helper-module-imports': 7.13.12
       babel-plugin-syntax-jsx: 6.18.0
-      lodash: 4.17.20
-      styled-components: 5.2.1_react-dom@17.0.1+react@17.0.1
+      lodash: 4.17.21
+      styled-components: 5.2.2_react-dom@17.0.2+react@17.0.2
     dev: false
     peerDependencies:
       styled-components: '>= 2'
@@ -2568,31 +2221,31 @@ packages:
     dev: false
     resolution:
       integrity: sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
-  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.12.17:
+  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.12.17
-      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.12.17
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.12.17
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.12.17
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.12.17
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.12.17
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.12.17
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.12.17
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.17
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.12.17
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.12.17
-      '@babel/plugin-syntax-top-level-await': 7.12.13_@babel+core@7.12.17
+      '@babel/core': 7.13.14
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.13.14
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.13.14
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.13.14
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.13.14
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.13.14
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-top-level-await': 7.12.13_@babel+core@7.13.14
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==
-  /babel-preset-jest/26.6.2_@babel+core@7.12.17:
+  /babel-preset-jest/26.6.2_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.12.17
+      '@babel/core': 7.13.14
       babel-plugin-jest-hoist: 26.6.2
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.12.17
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.13.14
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -2602,7 +2255,7 @@ packages:
       integrity: sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==
   /babel-runtime/6.26.0:
     dependencies:
-      core-js: 2.6.11
+      core-js: 2.6.12
       regenerator-runtime: 0.11.1
     dev: true
     resolution:
@@ -2658,7 +2311,7 @@ packages:
     dependencies:
       ansi-align: 2.0.0
       camelcase: 4.1.0
-      chalk: 2.4.2
+      chalk: 2.4.1
       cli-boxes: 1.0.0
       string-width: 2.1.1
       term-size: 1.2.0
@@ -2703,26 +2356,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
-  /browserslist/4.16.0:
-    dependencies:
-      caniuse-lite: 1.0.30001173
-      colorette: 1.2.1
-      electron-to-chromium: 1.3.634
-      escalade: 3.1.1
-      node-releases: 1.1.69
-    engines:
-      node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
-    hasBin: true
-    resolution:
-      integrity: sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==
   /browserslist/4.16.3:
     dependencies:
-      caniuse-lite: 1.0.30001199
+      caniuse-lite: 1.0.30001204
       colorette: 1.2.2
-      electron-to-chromium: 1.3.687
+      electron-to-chromium: 1.3.702
       escalade: 3.1.1
       node-releases: 1.1.71
-    dev: false
     engines:
       node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
     hasBin: true
@@ -2790,12 +2430,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
-  /call-bind/1.0.0:
+  /call-bind/1.0.2:
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.0.2
+      get-intrinsic: 1.1.1
     resolution:
-      integrity: sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==
+      integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
   /caller-callsite/2.0.0:
     dependencies:
       callsites: 2.0.0
@@ -2850,19 +2490,15 @@ packages:
       integrity: sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
   /caniuse-api/3.0.0:
     dependencies:
-      browserslist: 4.16.0
-      caniuse-lite: 1.0.30001173
+      browserslist: 4.16.3
+      caniuse-lite: 1.0.30001204
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     resolution:
       integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
-  /caniuse-lite/1.0.30001173:
+  /caniuse-lite/1.0.30001204:
     resolution:
-      integrity: sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==
-  /caniuse-lite/1.0.30001199:
-    dev: false
-    resolution:
-      integrity: sha512-ifbK2eChUCFUwGhlEzIoVwzFt1+iriSjyKKFYNfv6hN34483wyWpLLavYQXhnR036LhkdUYaSDpHg1El++VgHQ==
+      integrity: sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==
   /capture-exit/2.0.0:
     dependencies:
       rsvp: 4.8.5
@@ -2928,7 +2564,7 @@ packages:
     dependencies:
       anymatch: 3.1.1
       braces: 3.0.2
-      glob-parent: 5.1.1
+      glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.1
       normalize-path: 3.0.0
@@ -2970,7 +2606,7 @@ packages:
       integrity: sha1-T6kXw+WclKAEzWH47lCdplFocUM=
   /clipboardy/1.2.3:
     dependencies:
-      arch: 2.1.2
+      arch: 2.2.0
       execa: 0.8.0
     dev: true
     engines:
@@ -2979,7 +2615,7 @@ packages:
       integrity: sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==
   /cliui/6.0.0:
     dependencies:
-      string-width: 4.2.0
+      string-width: 4.2.2
       strip-ansi: 6.0.0
       wrap-ansi: 6.2.0
     dev: true
@@ -2987,7 +2623,7 @@ packages:
       integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
   /cliui/7.0.4:
     dependencies:
-      string-width: 4.2.0
+      string-width: 4.2.2
       strip-ansi: 6.0.0
       wrap-ansi: 7.0.0
     dev: true
@@ -3044,21 +2680,18 @@ packages:
   /color-name/1.1.4:
     resolution:
       integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-  /color-string/1.5.4:
+  /color-string/1.5.5:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
     resolution:
-      integrity: sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==
+      integrity: sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==
   /color/3.1.3:
     dependencies:
       color-convert: 1.9.3
-      color-string: 1.5.4
+      color-string: 1.5.5
     resolution:
       integrity: sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
-  /colorette/1.2.1:
-    resolution:
-      integrity: sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
   /colorette/1.2.2:
     resolution:
       integrity: sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
@@ -3102,7 +2735,7 @@ packages:
       integrity: sha1-xV2DzMG5TNUImk6T+niRxyY+Wao=
   /compressible/2.0.18:
     dependencies:
-      mime-db: 1.44.0
+      mime-db: 1.46.0
     dev: true
     engines:
       node: '>= 0.6'
@@ -3138,10 +2771,10 @@ packages:
   /concurrently/6.0.0:
     dependencies:
       chalk: 4.1.0
-      date-fns: 2.17.0
+      date-fns: 2.19.0
       lodash: 4.17.21
       read-pkg: 5.2.0
-      rxjs: 6.6.3
+      rxjs: 6.6.7
       spawn-command: 0.0.2-1
       supports-color: 8.1.1
       tree-kill: 1.2.2
@@ -3175,11 +2808,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
-  /core-js/2.6.11:
+  /core-js/2.6.12:
     deprecated: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
     requiresBuild: true
     resolution:
-      integrity: sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+      integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
   /core-util-is/1.0.2:
     dev: true
     resolution:
@@ -3198,9 +2831,9 @@ packages:
     dependencies:
       '@types/parse-json': 4.0.0
       import-fresh: 3.3.0
-      parse-json: 5.1.0
+      parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.0
+      yaml: 1.10.2
     engines:
       node: '>=10'
     resolution:
@@ -3393,10 +3026,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
-  /csstype/3.0.5:
-    dev: true
-    resolution:
-      integrity: sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==
   /csstype/3.0.7:
     dev: true
     resolution:
@@ -3413,18 +3042,12 @@ packages:
     dependencies:
       abab: 2.0.5
       whatwg-mimetype: 2.3.0
-      whatwg-url: 8.4.0
+      whatwg-url: 8.5.0
     dev: true
     engines:
       node: '>=10'
     resolution:
       integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==
-  /date-fns/2.17.0:
-    dev: true
-    engines:
-      node: '>=0.11'
-    resolution:
-      integrity: sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
   /date-fns/2.19.0:
     dev: true
     engines:
@@ -3594,7 +3217,7 @@ packages:
   /dom-serializer/0.2.2:
     dependencies:
       domelementtype: 2.1.0
-      entities: 2.1.0
+      entities: 2.2.0
     resolution:
       integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
   /domelementtype/1.3.1:
@@ -3631,13 +3254,9 @@ packages:
     dev: true
     resolution:
       integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
-  /electron-to-chromium/1.3.634:
+  /electron-to-chromium/1.3.702:
     resolution:
-      integrity: sha512-QPrWNYeE/A0xRvl/QP3E0nkaEvYUvH3gM04ZWYtIa6QlSpEetRlRI1xvQ7hiMIySHHEV+mwDSX8Kj4YZY6ZQAw==
-  /electron-to-chromium/1.3.687:
-    dev: false
-    resolution:
-      integrity: sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==
+      integrity: sha512-qJVUKFWQnF6wP7MmTngDkmm8/KPzaiTXNFOAg5j7DSa6J7kPou7mTBqC8jpUOxauQWwHR3pn4dMRdV8IE1xdtA==
   /email-addresses/3.1.0:
     dev: true
     resolution:
@@ -3676,64 +3295,45 @@ packages:
       node: '>=10.13.0'
     resolution:
       integrity: sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==
-  /entities/2.1.0:
+  /entities/2.2.0:
     resolution:
-      integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+      integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
   /error-ex/1.3.2:
     dependencies:
       is-arrayish: 0.2.1
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  /es-abstract/1.17.7:
+  /es-abstract/1.18.0:
     dependencies:
+      call-bind: 1.0.2
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
+      get-intrinsic: 1.1.1
       has: 1.0.3
-      has-symbols: 1.0.1
-      is-callable: 1.2.2
-      is-regex: 1.1.1
-      object-inspect: 1.9.0
-      object-keys: 1.1.1
-      object.assign: 4.1.2
-      string.prototype.trimend: 1.0.3
-      string.prototype.trimstart: 1.0.3
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
-  /es-abstract/1.18.0-next.1:
-    dependencies:
-      es-to-primitive: 1.2.1
-      function-bind: 1.1.1
-      has: 1.0.3
-      has-symbols: 1.0.1
-      is-callable: 1.2.2
+      has-symbols: 1.0.2
+      is-callable: 1.2.3
       is-negative-zero: 2.0.1
-      is-regex: 1.1.1
+      is-regex: 1.1.2
+      is-string: 1.0.5
       object-inspect: 1.9.0
       object-keys: 1.1.1
       object.assign: 4.1.2
-      string.prototype.trimend: 1.0.3
-      string.prototype.trimstart: 1.0.3
+      string.prototype.trimend: 1.0.4
+      string.prototype.trimstart: 1.0.4
+      unbox-primitive: 1.0.1
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==
+      integrity: sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==
   /es-to-primitive/1.2.1:
     dependencies:
-      is-callable: 1.2.2
+      is-callable: 1.2.3
       is-date-object: 1.0.2
       is-symbol: 1.0.3
     engines:
       node: '>= 0.4'
     resolution:
       integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
-  /esbuild/0.8.50:
-    dev: true
-    hasBin: true
-    requiresBuild: true
-    resolution:
-      integrity: sha512-oidFLXssA7IccYzkqLVZSqNJDwDq8Mh/vqvrW+3fPWM7iUiC5O2bCllhnO8+K9LlyL/2Z6n+WwRJAz9fqSIVRg==
   /esbuild/0.8.57:
     dev: true
     hasBin: true
@@ -3801,10 +3401,10 @@ packages:
   /eventemitter3/4.0.7:
     resolution:
       integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
-  /exec-sh/0.3.4:
+  /exec-sh/0.3.6:
     dev: true
     resolution:
-      integrity: sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
+      integrity: sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==
   /execa/0.7.0:
     dependencies:
       cross-spawn: 5.1.0
@@ -3956,11 +3556,11 @@ packages:
   /fast-deep-equal/3.1.3:
     resolution:
       integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-  /fast-glob/3.2.4:
+  /fast-glob/3.2.5:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
       '@nodelib/fs.walk': 1.2.6
-      glob-parent: 5.1.1
+      glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.2
       picomatch: 2.2.2
@@ -3968,7 +3568,7 @@ packages:
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+      integrity: sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
   /fast-json-stable-stringify/2.1.0:
     dev: true
     resolution:
@@ -3983,12 +3583,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=
-  /fastq/1.10.0:
+  /fastq/1.11.0:
     dependencies:
       reusify: 1.0.4
     dev: true
     resolution:
-      integrity: sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==
+      integrity: sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
   /fault/1.0.4:
     dependencies:
       format: 0.2.2
@@ -4060,10 +3660,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
-  /find-dependency/1.3.0:
+  /find-dependency/1.3.3:
     dev: true
     resolution:
-      integrity: sha512-3/jC4BIM4WvzO1b5m2QC1KPudgqcpTGGOA9lKMhQ9RUhGEvtS5oUGU2JlFWhhuFUK1I4MhrL66amf0qxkxhoIQ==
+      integrity: sha512-Fs4jjANCEF0ZQRXxoqU1XQFrC8D3gTs+xnluUu+2TR+02g3d05q6b6ucyWMkXOQoTUXAoMznG7V+EksSmvGhfQ==
   /find-up/4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -4086,7 +3686,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.27
+      mime-types: 2.1.29
     dev: true
     engines:
       node: '>= 0.12'
@@ -4108,7 +3708,7 @@ packages:
       integrity: sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   /fs-extra/8.1.0:
     dependencies:
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.6
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: true
@@ -4157,13 +3757,13 @@ packages:
       node: 6.* || 8.* || >= 10.*
     resolution:
       integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-  /get-intrinsic/1.0.2:
+  /get-intrinsic/1.1.1:
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
     resolution:
-      integrity: sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==
+      integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
   /get-package-type/0.1.0:
     dev: true
     engines:
@@ -4229,13 +3829,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==
-  /glob-parent/5.1.1:
+  /glob-parent/5.1.2:
     dependencies:
       is-glob: 4.0.1
     engines:
       node: '>= 6'
     resolution:
-      integrity: sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+      integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   /glob/7.1.6:
     dependencies:
       fs.realpath: 1.0.0
@@ -4252,11 +3852,11 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
-  /globby/11.0.2:
+  /globby/11.0.3:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.4
+      fast-glob: 3.2.5
       ignore: 5.1.8
       merge2: 1.4.1
       slash: 3.0.0
@@ -4264,7 +3864,7 @@ packages:
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
+      integrity: sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
   /globby/6.1.0:
     dependencies:
       array-union: 1.0.2
@@ -4286,7 +3886,7 @@ packages:
       integrity: sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
   /gray-matter/4.0.2:
     dependencies:
-      js-yaml: 3.14.0
+      js-yaml: 3.14.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -4316,6 +3916,9 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
+  /has-bigints/1.0.1:
+    resolution:
+      integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
   /has-flag/3.0.0:
     engines:
       node: '>=4'
@@ -4326,11 +3929,11 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-  /has-symbols/1.0.1:
+  /has-symbols/1.0.2:
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+      integrity: sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
   /has-value/0.3.1:
     dependencies:
       get-value: 2.0.6
@@ -4380,7 +3983,7 @@ packages:
       property-information: 5.6.0
       space-separated-tokens: 1.1.5
       style-to-object: 0.3.0
-      unist-util-is: 4.0.4
+      unist-util-is: 4.1.0
       web-namespaces: 1.1.4
     dev: false
     resolution:
@@ -4440,7 +4043,7 @@ packages:
       integrity: sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
   /history/4.10.1:
     dependencies:
-      '@babel/runtime': 7.10.5
+      '@babel/runtime': 7.13.10
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.1.0
@@ -4461,14 +4064,14 @@ packages:
   /hosted-git-info/2.8.8:
     resolution:
       integrity: sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
-  /hosted-git-info/4.0.0:
+  /hosted-git-info/4.0.2:
     dependencies:
       lru-cache: 6.0.0
     dev: true
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-fqhGdjk4av7mT9fU/B01dUtZ+WZSc/XEXMoLXDVZukiQRXxeHSSz3AqbeWRJHtF8EQYHlAgB1NSAHU0Cm7aqZA==
+      integrity: sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==
   /hsl-regex/1.0.0:
     resolution:
       integrity: sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=
@@ -4612,18 +4215,14 @@ packages:
   /inherits/2.0.4:
     resolution:
       integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-  /ini/1.3.5:
+  /ini/1.3.8:
     dev: true
     resolution:
-      integrity: sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+      integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
   /inline-style-parser/0.1.1:
     dev: false
     resolution:
       integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
-  /insert-css/2.0.0:
-    dev: true
-    resolution:
-      integrity: sha1-610Ql7dUL0x56jBg067gfQU4gPQ=
   /is-absolute-url/2.1.0:
     engines:
       node: '>=0.10.0'
@@ -4662,6 +4261,9 @@ packages:
   /is-arrayish/0.3.2:
     resolution:
       integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+  /is-bigint/1.0.1:
+    resolution:
+      integrity: sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==
   /is-binary-path/2.1.0:
     dependencies:
       binary-extensions: 2.2.0
@@ -4669,6 +4271,13 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  /is-boolean-object/1.1.0:
+    dependencies:
+      call-bind: 1.0.2
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==
   /is-buffer/1.1.6:
     dev: true
     resolution:
@@ -4679,11 +4288,11 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
-  /is-callable/1.2.2:
+  /is-callable/1.2.3:
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
+      integrity: sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
   /is-ci/2.0.0:
     dependencies:
       ci-info: 2.0.0
@@ -4820,6 +4429,11 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+  /is-number-object/1.0.4:
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
   /is-number/3.0.0:
     dependencies:
       kind-of: 3.2.2
@@ -4863,17 +4477,18 @@ packages:
       integrity: sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
   /is-reference/1.2.1:
     dependencies:
-      '@types/estree': 0.0.46
+      '@types/estree': 0.0.47
     dev: true
     resolution:
       integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
-  /is-regex/1.1.1:
+  /is-regex/1.1.2:
     dependencies:
-      has-symbols: 1.0.1
+      call-bind: 1.0.2
+      has-symbols: 1.0.2
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
+      integrity: sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
   /is-resolvable/1.1.0:
     resolution:
       integrity: sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
@@ -4889,6 +4504,11 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+  /is-string/1.0.5:
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
   /is-subdir/1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
@@ -4906,7 +4526,7 @@ packages:
       integrity: sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==
   /is-symbol/1.0.3:
     dependencies:
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
     engines:
       node: '>= 0.4'
     resolution:
@@ -4976,7 +4596,7 @@ packages:
       integrity: sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
   /istanbul-lib-instrument/4.0.3:
     dependencies:
-      '@babel/core': 7.12.17
+      '@babel/core': 7.13.14
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.0.0
       semver: 6.3.0
@@ -5047,10 +4667,10 @@ packages:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-config/26.6.3:
     dependencies:
-      '@babel/core': 7.12.17
+      '@babel/core': 7.13.14
       '@jest/test-sequencer': 26.6.3
       '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.12.17
+      babel-jest: 26.6.3_@babel+core@7.13.14
       chalk: 4.1.0
       deepmerge: 4.2.2
       glob: 7.1.6
@@ -5110,10 +4730,10 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       jest-mock: 26.6.2
       jest-util: 26.6.2
-      jsdom: 16.5.1
+      jsdom: 16.5.2
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -5124,7 +4744,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       jest-mock: 26.6.2
       jest-util: 26.6.2
     dev: true
@@ -5142,7 +4762,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.5
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       anymatch: 3.1.1
       fb-watchman: 2.0.1
       graceful-fs: 4.2.6
@@ -5162,12 +4782,12 @@ packages:
       integrity: sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==
   /jest-jasmine2/26.6.3:
     dependencies:
-      '@babel/traverse': 7.12.17
+      '@babel/traverse': 7.13.13
       '@jest/environment': 26.6.2
       '@jest/source-map': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       chalk: 4.1.0
       co: 4.6.0
       expect: 26.6.2
@@ -5224,7 +4844,7 @@ packages:
   /jest-mock/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -5280,7 +4900,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       chalk: 4.1.0
       emittery: 0.7.2
       exit: 0.1.2
@@ -5338,7 +4958,7 @@ packages:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-serializer/26.6.2:
     dependencies:
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       graceful-fs: 4.2.6
     dev: true
     engines:
@@ -5347,10 +4967,10 @@ packages:
       integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==
   /jest-snapshot/26.6.2:
     dependencies:
-      '@babel/types': 7.12.17
+      '@babel/types': 7.13.14
       '@jest/types': 26.6.2
       '@types/babel__traverse': 7.11.1
-      '@types/prettier': 2.2.2
+      '@types/prettier': 2.2.3
       chalk: 4.1.0
       expect: 26.6.2
       graceful-fs: 4.2.6
@@ -5362,7 +4982,7 @@ packages:
       jest-resolve: 26.6.2
       natural-compare: 1.4.0
       pretty-format: 26.6.2
-      semver: 7.3.4
+      semver: 7.3.5
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -5371,7 +4991,7 @@ packages:
   /jest-util/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       chalk: 4.1.0
       graceful-fs: 4.2.6
       is-ci: 2.0.0
@@ -5398,11 +5018,11 @@ packages:
     dependencies:
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.31
-      ansi-escapes: 4.3.1
+      '@types/node': 14.14.37
+      ansi-escapes: 4.3.2
       chalk: 4.1.0
       jest-util: 26.6.2
-      string-length: 4.0.1
+      string-length: 4.0.2
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -5410,7 +5030,7 @@ packages:
       integrity: sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==
   /jest-worker/26.6.2:
     dependencies:
-      '@types/node': 14.14.31
+      '@types/node': 14.14.37
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -5429,9 +5049,9 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
-  /jotai/0.15.3_react@17.0.1:
+  /jotai/0.15.5_react@17.0.2:
     dependencies:
-      react: 17.0.1
+      react: 17.0.2
     dev: false
     peerDependencies:
       immer: '*'
@@ -5449,7 +5069,7 @@ packages:
       xstate:
         optional: true
     resolution:
-      integrity: sha512-4+0Ie61mSQjyEuh/vCKKr7JFclDe/9DxV2rhzGRRZwnCcmgld8AdGX9BnRqfjMedyYpS3qATzLjIcCG0CopgMg==
+      integrity: sha512-Q9YCdIcqNUlZG2K5UA2qc1utDuWM9P6dlkJqZykCNUik783fipHprJzvIU2nk36NAPnbZnrAK2owX3WXkKKjpQ==
   /jpeg-js/0.4.3:
     dev: true
     resolution:
@@ -5457,14 +5077,6 @@ packages:
   /js-tokens/4.0.0:
     resolution:
       integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-  /js-yaml/3.14.0:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
   /js-yaml/3.14.1:
     dependencies:
       argparse: 1.0.10
@@ -5483,7 +5095,7 @@ packages:
     dev: true
     resolution:
       integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
-  /jsdom/16.5.1:
+  /jsdom/16.5.2:
     dependencies:
       abab: 2.0.5
       acorn: 8.1.0
@@ -5508,7 +5120,7 @@ packages:
       webidl-conversions: 6.1.0
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
-      whatwg-url: 8.4.0
+      whatwg-url: 8.5.0
       ws: 7.4.4
       xml-name-validator: 3.0.0
     dev: true
@@ -5520,7 +5132,7 @@ packages:
       canvas:
         optional: true
     resolution:
-      integrity: sha512-pF73EOsJgwZekbDHEY5VO/yKXUkab/DuvrQB/ANVizbr6UAHJsDdHXuotZYwkJSGQl1JM+ivXaqY+XBDDL4TiA==
+      integrity: sha512-JxNtPt9C1ut85boCbJmffaQ06NBnzkQY/MWO3YxPW8IWS38A26z+B1oBvA9LwKrytewdfymnhi4UNH3/RAgZrg==
   /jsesc/0.5.0:
     dev: false
     hasBin: true
@@ -5562,14 +5174,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  /json5/2.1.3:
-    dependencies:
-      minimist: 1.2.5
-    engines:
-      node: '>=6'
-    hasBin: true
-    resolution:
-      integrity: sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
   /json5/2.2.0:
     dependencies:
       minimist: 1.2.5
@@ -5581,7 +5185,7 @@ packages:
   /jsonfile/4.0.0:
     dev: true
     optionalDependencies:
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.6
     resolution:
       integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   /jsonfile/6.1.0:
@@ -5653,6 +5257,17 @@ packages:
   /lines-and-columns/1.1.6:
     resolution:
       integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+  /load-json-file/6.2.0:
+    dependencies:
+      graceful-fs: 4.2.6
+      parse-json: 5.2.0
+      strip-bom: 4.0.0
+      type-fest: 0.6.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==
   /loader-utils/1.4.0:
     dependencies:
       big.js: 5.2.2
@@ -5679,20 +5294,9 @@ packages:
   /lodash.memoize/4.1.2:
     resolution:
       integrity: sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-  /lodash.sortby/4.7.0:
-    dev: true
-    resolution:
-      integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
   /lodash.uniq/4.5.0:
     resolution:
       integrity: sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
-  /lodash/4.17.19:
-    dev: true
-    resolution:
-      integrity: sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-  /lodash/4.17.20:
-    resolution:
-      integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
   /lodash/4.17.21:
     resolution:
       integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5858,12 +5462,12 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==
-  /mime-db/1.44.0:
+  /mime-db/1.46.0:
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+      integrity: sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
   /mime-types/2.1.18:
     dependencies:
       mime-db: 1.33.0
@@ -5872,14 +5476,14 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
-  /mime-types/2.1.27:
+  /mime-types/2.1.29:
     dependencies:
-      mime-db: 1.44.0
+      mime-db: 1.46.0
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+      integrity: sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==
   /mime/2.5.2:
     dev: true
     engines:
@@ -5893,27 +5497,27 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-  /mini-create-react-context/0.4.0_prop-types@15.7.2+react@17.0.1:
+  /mini-create-react-context/0.4.1_prop-types@15.7.2+react@17.0.2:
     dependencies:
-      '@babel/runtime': 7.10.5
+      '@babel/runtime': 7.13.10
       prop-types: 15.7.2
-      react: 17.0.1
+      react: 17.0.2
       tiny-warning: 1.0.3
     dev: false
     peerDependencies:
       prop-types: ^15.0.0
-      react: ^0.14.0 || ^15.0.0 || ^16.0.0
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     resolution:
-      integrity: sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==
+      integrity: sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
   /mini-debounce/1.0.8:
     dev: false
     resolution:
       integrity: sha512-EqUsV34zuw2N9UHjRl1bwaDiLe1d/P8AemSp/EbDjOsZ7gB+z+7F9wcJWqfU3QpPnHD1oKGe2n6Fw90QsLkBkA==
-  /mini-store/3.0.6_react-dom@17.0.1+react@17.0.1:
+  /mini-store/3.0.6_react-dom@17.0.2+react@17.0.2:
     dependencies:
       hoist-non-react-statics: 3.3.2
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       shallowequal: 1.1.0
     dev: true
     peerDependencies:
@@ -5971,13 +5575,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
-  /nanoid/3.1.21:
+  /nanoid/3.1.22:
     dev: true
     engines:
       node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1
     hasBin: true
     resolution:
-      integrity: sha512-A6oZraK4DJkAOICstsGH98dvycPr/4GGDH7ZWKmMdd3vGcOurZ6JmWFUt0DA5bzrrn2FrUjmv6mFNWvv8jpppA==
+      integrity: sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
   /nanomatch/1.2.13:
     dependencies:
       arr-diff: 4.0.0
@@ -6024,7 +5628,7 @@ packages:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.3.4
+      semver: 7.3.5
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -6032,11 +5636,7 @@ packages:
     optional: true
     resolution:
       integrity: sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==
-  /node-releases/1.1.69:
-    resolution:
-      integrity: sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==
   /node-releases/1.1.71:
-    dev: false
     resolution:
       integrity: sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
   /normalize-package-data/2.5.0:
@@ -6047,17 +5647,17 @@ packages:
       validate-npm-package-license: 3.0.4
     resolution:
       integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
-  /normalize-package-data/3.0.1:
+  /normalize-package-data/3.0.2:
     dependencies:
-      hosted-git-info: 4.0.0
+      hosted-git-info: 4.0.2
       resolve: 1.20.0
-      semver: 7.3.4
+      semver: 7.3.5
       validate-npm-package-license: 3.0.4
     dev: true
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-D/ttLdxo71msR4FF3VgSwK4blHfE3/vGByz1NCeE7/Dh8reQOKNJJjk5L10mLq9jxa+ZHzT1/HLgxljzbXE7Fw==
+      integrity: sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==
   /normalize-path/2.1.1:
     dependencies:
       remove-trailing-separator: 1.1.0
@@ -6087,10 +5687,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
-  /npm-normalize-package-bin/1.0.1:
-    dev: true
-    resolution:
-      integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
   /npm-run-path/2.0.2:
     dependencies:
       path-key: 2.0.1
@@ -6153,23 +5749,23 @@ packages:
       integrity: sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   /object.assign/4.1.2:
     dependencies:
-      call-bind: 1.0.0
+      call-bind: 1.0.2
       define-properties: 1.1.3
-      has-symbols: 1.0.1
+      has-symbols: 1.0.2
       object-keys: 1.1.1
     engines:
       node: '>= 0.4'
     resolution:
       integrity: sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
-  /object.getownpropertydescriptors/2.1.1:
+  /object.getownpropertydescriptors/2.1.2:
     dependencies:
-      call-bind: 1.0.0
+      call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.1
+      es-abstract: 1.18.0
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==
+      integrity: sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==
   /object.pick/1.3.0:
     dependencies:
       isobject: 3.0.1
@@ -6178,16 +5774,16 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
-  /object.values/1.1.2:
+  /object.values/1.1.3:
     dependencies:
-      call-bind: 1.0.0
+      call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0-next.1
+      es-abstract: 1.18.0
       has: 1.0.3
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==
+      integrity: sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==
   /on-headers/1.0.2:
     dev: true
     engines:
@@ -6233,14 +5829,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==
-  /p-filter/2.1.0:
-    dependencies:
-      p-map: 2.1.0
-    dev: true
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==
   /p-finally/1.0.0:
     engines:
       node: '>=4'
@@ -6260,12 +5848,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
-  /p-map/2.1.0:
-    dev: true
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
   /p-queue/6.6.2:
     dependencies:
       eventemitter3: 4.0.7
@@ -6327,16 +5909,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  /parse-json/5.1.0:
-    dependencies:
-      '@babel/code-frame': 7.12.11
-      error-ex: 1.3.2
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.1.6
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
   /parse-json/5.2.0:
     dependencies:
       '@babel/code-frame': 7.12.13
@@ -6498,7 +6070,7 @@ packages:
       integrity: sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==
   /postcss-colormin/4.0.3:
     dependencies:
-      browserslist: 4.16.0
+      browserslist: 4.16.3
       color: 3.1.3
       has: 1.0.3
       postcss: 7.0.35
@@ -6543,14 +6115,14 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==
-  /postcss-load-config/3.0.0:
+  /postcss-load-config/3.0.1:
     dependencies:
       cosmiconfig: 7.0.0
       import-cwd: 3.0.0
     engines:
       node: '>= 10'
     resolution:
-      integrity: sha512-lErrN8imuEF1cSiHBV8MiR7HeuzlDpCGNtaMyYHlOBuJHHOGw6S4xOMZp8BbXPr7AGQp14L6PZDlIOpfFJ6f7w==
+      integrity: sha512-/pDHe30UYZUD11IeG8GWx9lNtu1ToyTsZHnyy45B4Mrwr/Kb6NgYl7k753+05CJNKnjbwh4975amoPJ+TEjHNQ==
   /postcss-merge-longhand/4.0.11:
     dependencies:
       css-color-names: 0.0.4
@@ -6563,7 +6135,7 @@ packages:
       integrity: sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==
   /postcss-merge-rules/4.0.3:
     dependencies:
-      browserslist: 4.16.0
+      browserslist: 4.16.3
       caniuse-api: 3.0.0
       cssnano-util-same-parent: 4.0.1
       postcss: 7.0.35
@@ -6594,7 +6166,7 @@ packages:
   /postcss-minify-params/4.0.2:
     dependencies:
       alphanum-sort: 1.0.2
-      browserslist: 4.16.0
+      browserslist: 4.16.3
       cssnano-util-get-arguments: 4.0.0
       postcss: 7.0.35
       postcss-value-parser: 3.3.1
@@ -6719,7 +6291,7 @@ packages:
       integrity: sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==
   /postcss-normalize-unicode/4.0.1:
     dependencies:
-      browserslist: 4.16.0
+      browserslist: 4.16.3
       postcss: 7.0.35
       postcss-value-parser: 3.3.1
     engines:
@@ -6755,7 +6327,7 @@ packages:
       integrity: sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==
   /postcss-reduce-initial/4.0.3:
     dependencies:
-      browserslist: 4.16.0
+      browserslist: 4.16.3
       caniuse-api: 3.0.0
       has: 1.0.3
       postcss: 7.0.35
@@ -6829,7 +6401,7 @@ packages:
   /postcss/8.2.8:
     dependencies:
       colorette: 1.2.2
-      nanoid: 3.1.21
+      nanoid: 3.1.22
       source-map: 0.6.1
     dev: true
     engines:
@@ -6853,24 +6425,15 @@ packages:
       '@jest/types': 26.6.2
       ansi-regex: 5.0.0
       ansi-styles: 4.3.0
-      react-is: 17.0.1
+      react-is: 17.0.2
     dev: true
     engines:
       node: '>= 10'
     resolution:
       integrity: sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
-  /prism-react-renderer/1.1.1_react@17.0.1:
+  /prism-react-renderer/1.2.0_react@17.0.2:
     dependencies:
-      react: 17.0.1
-    dev: false
-    peerDependencies:
-      react: '>=0.14.9'
-    resolution:
-      integrity: sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug==
-  /prism-react-renderer/1.2.0_react@17.0.1:
-    dependencies:
-      react: 17.0.1
-    dev: true
+      react: 17.0.2
     peerDependencies:
       react: '>=0.14.9'
     resolution:
@@ -6966,6 +6529,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-u7aTucqRXCMlFbIosaArYJBD2+s=
+  /queue-microtask/1.2.3:
+    dev: true
+    resolution:
+      integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
   /ramda/0.27.1:
     dev: true
     resolution:
@@ -6976,14 +6543,14 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
-  /rc-align/4.0.9_react-dom@17.0.1+react@17.0.1:
+  /rc-align/4.0.9_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
       dom-align: 1.12.0
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       resize-observer-polyfill: 1.5.1
     dev: true
     peerDependencies:
@@ -6991,14 +6558,14 @@ packages:
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-myAM2R4qoB6LqBul0leaqY8gFaiECDJ3MtQDmzDo9xM9NRT/04TvWOYd2YHU9zvGzqk9QXF6S9/MifzSKDZeMw==
-  /rc-cascader/1.4.2_react-dom@17.0.1+react@17.0.1:
+  /rc-cascader/1.4.2_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       array-tree-filter: 2.1.0
-      rc-trigger: 5.2.3_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-trigger: 5.2.3_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       warning: 4.0.3
     dev: true
     peerDependencies:
@@ -7006,26 +6573,26 @@ packages:
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-JVuLGrSi+3G8DZyPvlKlGVWJjhoi9NTz6REHIgRspa5WnznRkKGm2ejb0jJtz0m2IL8Q9BG4ZA2sXuqAu71ltQ==
-  /rc-checkbox/2.3.2_react-dom@17.0.1+react@17.0.1:
+  /rc-checkbox/2.3.2_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-afVi1FYiGv1U0JlpNH/UaEXdh6WUJjcWokj/nUN2TgG80bfG+MDdbfHKlLcNNba94mbjy2/SXJ1HDgrOkXGAjg==
-  /rc-collapse/3.1.0_react-dom@17.0.1+react@17.0.1:
+  /rc-collapse/3.1.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-motion: 2.4.1_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-motion: 2.4.1_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       shallowequal: 1.1.0
     dev: true
     peerDependencies:
@@ -7033,53 +6600,53 @@ packages:
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-EwpNPJcLe7b+5JfyaxM9ZNnkCgqArt3QQO0Cr5p5plwz/C9h8liAmjYY5I4+hl9lAjBqb7ZwLu94+z+rt5g1WQ==
-  /rc-dialog/8.5.2_react-dom@17.0.1+react@17.0.1:
+  /rc-dialog/8.5.2_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-motion: 2.4.1_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-motion: 2.4.1_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-3n4taFcjqhTE9uNuzjB+nPDeqgRBTEGBfe46mb1e7r88DgDo0lL4NnxY/PZ6PJKd2tsCt+RrgF/+YeTvJ/Thsw==
-  /rc-drawer/4.3.1_react-dom@17.0.1+react@17.0.1:
+  /rc-drawer/4.3.1_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-GMfFy4maqxS9faYXEhQ+0cA1xtkddEQzraf6SAdzWbn444DrrLogwYPk1NXSpdXjLCLxgxOj9MYtyYG42JsfXg==
-  /rc-dropdown/3.2.0_react-dom@17.0.1+react@17.0.1:
+  /rc-dropdown/3.2.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-trigger: 5.2.3_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-trigger: 5.2.3_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '*'
       react-dom: '*'
     resolution:
       integrity: sha512-j1HSw+/QqlhxyTEF6BArVZnTmezw2LnSmRk6I9W7BCqNCKaRwleRmMMs1PHbuaG8dKHVqP6e21RQ7vPBLVnnNw==
-  /rc-field-form/1.20.0_react-dom@17.0.1+react@17.0.1:
+  /rc-field-form/1.20.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       async-validator: 3.5.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     engines:
       node: '>=8.x'
@@ -7088,59 +6655,59 @@ packages:
       react-dom: '>= 16.9.0'
     resolution:
       integrity: sha512-jkzsIfXR7ywEYdeAtktt1aLff88wxIPDLpq7KShHNl4wlsWrCE+TzkXBfjvVzYOVZt5GGrD8YDqNO/q6eaR/eA==
-  /rc-image/5.2.3_react-dom@17.0.1+react@17.0.1:
+  /rc-image/5.2.4_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-dialog: 8.5.2_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-dialog: 8.5.2_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
-      integrity: sha512-8qWNerW1rN0s4zAF6oEa+Zm7UzM+PwTxbGdufvnR3Gcp2M0bcfoEPk9V+RgTxmzGNNELxmrMHloPL4LV5BZu3Q==
-  /rc-input-number/7.0.2_react-dom@17.0.1+react@17.0.1:
+      integrity: sha512-kWOjhZC1OoGKfvWqtDoO9r8WUNswBwnjcstI6rf7HMudz0usmbGvewcWqsOhyaBRJL9+I4eeG+xiAoxV1xi75Q==
+  /rc-input-number/7.0.3_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
-      integrity: sha512-9AcD3/D18Oa41xZnBFvJ0fdp6AJkf/en8uKi8E69Ct+sh64qIYbWUXeh1PXhJgrCHIoNNT8OWaTebypT4/d3ZA==
-  /rc-mentions/1.5.3_react-dom@17.0.1+react@17.0.1:
+      integrity: sha512-y0nVqVANWyxQbm/vdhz1p5E1V5Y6Yd2+3MGKntSzCxrYgw0F7/COXkbRdcTECnXwiDv8ZrbYQ1pTP3u43PqE4Q==
+  /rc-mentions/1.5.3_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-menu: 8.10.6_react-dom@17.0.1+react@17.0.1
-      rc-textarea: 0.3.4_react-dom@17.0.1+react@17.0.1
-      rc-trigger: 5.2.3_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-menu: 8.10.7_react-dom@17.0.2+react@17.0.2
+      rc-textarea: 0.3.4_react-dom@17.0.2+react@17.0.2
+      rc-trigger: 5.2.3_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-NG/KB8YiKBCJPHHvr/QapAb4f9YzLJn7kDHtmI1K6t7ZMM5YgrjIxNNhoRKKP9zJvb9PdPts69Hbg4ZMvLVIFQ==
-  /rc-menu/8.10.6_react-dom@17.0.1+react@17.0.1:
+  /rc-menu/8.10.7_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      mini-store: 3.0.6_react-dom@17.0.1+react@17.0.1
-      rc-motion: 2.4.1_react-dom@17.0.1+react@17.0.1
-      rc-trigger: 5.2.3_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      mini-store: 3.0.6_react-dom@17.0.2+react@17.0.2
+      rc-motion: 2.4.1_react-dom@17.0.2+react@17.0.2
+      rc-trigger: 5.2.3_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       resize-observer-polyfill: 1.5.1
       shallowequal: 1.1.0
     dev: true
@@ -7148,28 +6715,28 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
-      integrity: sha512-RVkd8XChwSmVOdNULbqLNnABthRZWnhqct1Q74onEXTClsXvsLADMhlIJtw/umglVSECM+14TJdIli9rl2Bzlw==
-  /rc-motion/2.4.1_react-dom@17.0.1+react@17.0.1:
+      integrity: sha512-m/ypV7OjkkUsMdutzMUxEI8tWyi0Y1TQ5YkSDk7k2uv2aCKkHYEoDKsDAfcPeejo3HMo2z5unWE+jD+dCphraw==
+  /rc-motion/2.4.1_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-TWLvymfMu8SngPx5MDH8dQ0D2RYbluNTfam4hY/dNNx9RQ3WtGuZ/GXHi2ymLMzH+UNd6EEFYkOuR5JTTtm8Xg==
-  /rc-notification/4.5.5_react-dom@17.0.1+react@17.0.1:
+  /rc-notification/4.5.5_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-motion: 2.4.1_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-motion: 2.4.1_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     engines:
       node: '>=8.x'
@@ -7178,42 +6745,42 @@ packages:
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-YIfhTSw+h5GsSdgMnuMx24wqiPlg3FeamuOlkh9RkyHx+SeZVAKzQ0juy2NGvPEF2hDWi5xTqxUqLdo0L2AmGg==
-  /rc-overflow/1.0.2_react-dom@17.0.1+react@17.0.1:
+  /rc-overflow/1.0.2_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-resize-observer: 1.0.0_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-resize-observer: 1.0.0_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-GXj4DAyNxm4f57LvXLwhJaZoJHzSge2l2lQq64MZP7NJAfLpQqOLD+v9JMV9ONTvDPZe8kdzR+UMmkAn7qlzFA==
-  /rc-pagination/3.1.6_react-dom@17.0.1+react@17.0.1:
+  /rc-pagination/3.1.6_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-Pb2zJEt8uxXzYCWx/2qwsYZ3vSS9Eqdw0cJBli6C58/iYhmvutSBqrBJh51Z5UzYc5ZcW5CMeP5LbbKE1J3rpw==
-  /rc-picker/2.5.10_react-dom@17.0.1+react@17.0.1:
+  /rc-picker/2.5.10_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
       date-fns: 2.19.0
       moment: 2.29.1
-      rc-trigger: 5.2.3_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-trigger: 5.2.3_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       shallowequal: 1.1.0
     dev: true
     engines:
@@ -7224,25 +6791,25 @@ packages:
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-d2or2jql9SSY8CaRPybpbKkXBq3bZ6g88UKyWQZBLTCrc92Xm87RfRC/P3UEQo/CLmia3jVF7IXVi1HmNe2DZA==
-  /rc-progress/3.1.3_react-dom@17.0.1+react@17.0.1:
+  /rc-progress/3.1.3_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-Jl4fzbBExHYMoC6HBPzel0a9VmhcSXx24LVt/mdhDM90MuzoMCJjXZAlhA0V0CJi+SKjMhfBoIQ6Lla1nD4QNw==
-  /rc-rate/2.9.1_react-dom@17.0.1+react@17.0.1:
+  /rc-rate/2.9.1_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     engines:
       node: '>=8.x'
@@ -7251,13 +6818,13 @@ packages:
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-MmIU7FT8W4LYRRHJD1sgG366qKtSaKb67D0/vVvJYR0lrCuRrCiVQ5qhfT5ghVO4wuVIORGpZs7ZKaYu+KMUzA==
-  /rc-resize-observer/1.0.0_react-dom@17.0.1+react@17.0.1:
+  /rc-resize-observer/1.0.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       resize-observer-polyfill: 1.5.1
     dev: true
     peerDependencies:
@@ -7265,17 +6832,17 @@ packages:
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-RgKGukg1mlzyGdvzF7o/LGFC8AeoMH9aGzXTUdp6m+OApvmRdUuOscq/Y2O45cJA+rXt1ApWlpFoOIioXL3AGg==
-  /rc-select/12.1.6_react-dom@17.0.1+react@17.0.1:
+  /rc-select/12.1.7_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-motion: 2.4.1_react-dom@17.0.1+react@17.0.1
-      rc-overflow: 1.0.2_react-dom@17.0.1+react@17.0.1
-      rc-trigger: 5.2.3_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      rc-virtual-list: 3.2.6_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-motion: 2.4.1_react-dom@17.0.2+react@17.0.2
+      rc-overflow: 1.0.2_react-dom@17.0.2+react@17.0.2
+      rc-trigger: 5.2.3_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      rc-virtual-list: 3.2.6_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     engines:
       node: '>=8.x'
@@ -7283,15 +6850,15 @@ packages:
       react: '*'
       react-dom: '*'
     resolution:
-      integrity: sha512-lsS95CUCRUObLcZvBecAdLS8RcIQQOuWC+A+xJOogvQJFEqIx4o8bcRH9OOob8eGKg7F84dKEz0hYUSEknwwew==
-  /rc-slider/9.7.1_react-dom@17.0.1+react@17.0.1:
+      integrity: sha512-sLZlfp+U7Typ+jPM5gTi8I4/oJalRw8kyhxZZ9Q4mEfO2p+otd1Chmzhh+wPraBY3IwE0RZM2/x1Leg/kQKk/w==
+  /rc-slider/9.7.2_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-tooltip: 5.1.0_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-tooltip: 5.1.0_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       shallowequal: 1.1.0
     dev: true
     engines:
@@ -7300,14 +6867,14 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
-      integrity: sha512-r9r0dpFA3PEvxBhIfVi1lVzxuSogWxeY+tGvi2AqMM1rPgaOXQ7WbtT+9kVFkJ9K8TntA/vYPgiCCKfN29KTkw==
-  /rc-steps/4.1.3_react-dom@17.0.1+react@17.0.1:
+      integrity: sha512-mVaLRpDo6otasBs6yVnG02ykI3K6hIrLTNfT5eyaqduFv95UODI9PDS6fWuVVehVpdS4ENgOSwsTjrPVun+k9g==
+  /rc-steps/4.1.3_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     engines:
       node: '>=8.x'
@@ -7316,27 +6883,27 @@ packages:
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-GXrMfWQOhN3sVze3JnzNboHpQdNHcdFubOETUHyDpa/U3HEKBZC3xJ8XK4paBgF4OJ3bdUVLC+uBPc6dCxvDYA==
-  /rc-switch/3.2.2_react-dom@17.0.1+react@17.0.1:
+  /rc-switch/3.2.2_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==
-  /rc-table/7.13.2_react-dom@17.0.1+react@17.0.1:
+  /rc-table/7.13.3_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-resize-observer: 1.0.0_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-resize-observer: 1.0.0_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       shallowequal: 1.1.0
     dev: true
     engines:
@@ -7345,17 +6912,17 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
-      integrity: sha512-KWYSGpWPAxX7PBIhxlkVo7XvoT3ZjPnDorm95NubK6udxxs0hDwzuQDqNJ2iiNuimSZj1FL+27aE606eobS96w==
-  /rc-tabs/11.7.3_react-dom@17.0.1+react@17.0.1:
+      integrity: sha512-oP4fknjvKCZAaiDnvj+yzBaWcg+JYjkASbeWonU1BbrLcomkpKvMUgPODNEzg0QdXA9OGW0PO86h4goDSW06Kg==
+  /rc-tabs/11.7.3_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-dropdown: 3.2.0_react-dom@17.0.1+react@17.0.1
-      rc-menu: 8.10.6_react-dom@17.0.1+react@17.0.1
-      rc-resize-observer: 1.0.0_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-dropdown: 3.2.0_react-dom@17.0.2+react@17.0.2
+      rc-menu: 8.10.7_react-dom@17.0.2+react@17.0.2
+      rc-resize-observer: 1.0.0_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     engines:
       node: '>=8.x'
@@ -7364,56 +6931,56 @@ packages:
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-5nd2NVss9TprPRV9r8N05SjQyAE7zDrLejxFLcbJ+BdLxSwnGnk3ws/Iq0smqKZUnPQC0XEvnpF3+zlllUUT2w==
-  /rc-textarea/0.3.4_react-dom@17.0.1+react@17.0.1:
+  /rc-textarea/0.3.4_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-resize-observer: 1.0.0_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-resize-observer: 1.0.0_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-ILUYx831ZukQPv3m7R4RGRtVVWmL1LV4ME03L22mvT56US0DGCJJaRTHs4vmpcSjFHItph5OTmhodY4BOwy81A==
-  /rc-tooltip/5.1.0_react-dom@17.0.1+react@17.0.1:
+  /rc-tooltip/5.1.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
-      rc-trigger: 5.2.3_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-trigger: 5.2.3_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-pFqD1JZwNIpbdcefB7k5xREoHAWM/k3yQwYF0iminbmDXERgq4rvBfUwIvlCqqZSM7HDr9hYeYr6ZsVNaKtvCQ==
-  /rc-tree-select/4.3.0_react-dom@17.0.1+react@17.0.1:
+  /rc-tree-select/4.3.1_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-select: 12.1.6_react-dom@17.0.1+react@17.0.1
-      rc-tree: 4.1.5_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-select: 12.1.7_react-dom@17.0.2+react@17.0.2
+      rc-tree: 4.1.5_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '*'
       react-dom: '*'
     resolution:
-      integrity: sha512-EEXB9dKBsJNJuKIU5NERZsaJ71GDGIj5uWLl7A4XiYr2jXM4JICfScvvp3O5jHMDfhqmgpqNc0z90mHkgh3hKg==
-  /rc-tree/4.1.5_react-dom@17.0.1+react@17.0.1:
+      integrity: sha512-OeV8u5kBEJ8MbatP04Rh8T3boOHGjdGBTEm1a0bubBbB2GNNhlMOr4ZxezkHYtXf02JdBS/WyydmI/RMjXgtJA==
+  /rc-tree/4.1.5_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-motion: 2.4.1_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      rc-virtual-list: 3.2.6_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-motion: 2.4.1_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      rc-virtual-list: 3.2.6_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     engines:
       node: '>=8.x'
@@ -7422,15 +6989,15 @@ packages:
       react-dom: '*'
     resolution:
       integrity: sha512-q2vjcmnBDylGZ9/ZW4F9oZMKMJdbFWC7um+DAQhZG1nqyg1iwoowbBggUDUaUOEryJP+08bpliEAYnzJXbI5xQ==
-  /rc-trigger/5.2.3_react-dom@17.0.1+react@17.0.1:
+  /rc-trigger/5.2.3_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-align: 4.0.9_react-dom@17.0.1+react@17.0.1
-      rc-motion: 2.4.1_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-align: 4.0.9_react-dom@17.0.2+react@17.0.2
+      rc-motion: 2.4.1_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     engines:
       node: '>=8.x'
@@ -7439,24 +7006,24 @@ packages:
       react-dom: '>=16.9.0'
     resolution:
       integrity: sha512-6Fokao07HUbqKIDkDRFEM0AGZvsvK0Fbp8A/KFgl1ngaqfO1nY037cISCG1Jm5fxImVsXp9awdkP7Vu5cxjjog==
-  /rc-upload/4.2.0-alpha.0_react-dom@17.0.1+react@17.0.1:
+  /rc-upload/4.2.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
       classnames: 2.2.6
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
-      integrity: sha512-44mVeg9+FwcHVLheYovApS/Q676/dHglRbb9vEYcgqGoR0poP0ssYZ9mtmKxdgr2g5EJe7nGFljbfnyEmluCqQ==
-  /rc-util/5.8.1_react-dom@17.0.1+react@17.0.1:
+      integrity: sha512-BXtvBs1PnwLjaUzBBU5z4yb9NMSaxc6mUIoPmS9LUAzaTz12L3TLrwu+8dnopYUiyLmYFS3LEO7aUfEWBqJfSA==
+  /rc-util/5.9.8_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@babel/runtime': 7.13.10
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       react-is: 16.13.1
       shallowequal: 1.1.0
     dev: true
@@ -7464,14 +7031,14 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     resolution:
-      integrity: sha512-kXV/QjL+azh3AxMk68gm8+nltVoL6bjeJJULAZLRCLus2Fhvo/aaMZokxYov/E0dbfjo31I78pF4yVljqQB7bA==
-  /rc-virtual-list/3.2.6_react-dom@17.0.1+react@17.0.1:
+      integrity: sha512-typLSHYGf5irvGLYQshs0Ra3aze086h0FhzsAkyirMunYZ7b3Te8gKa5PVaanoHaZa9sS6qx98BxgysoRP+6Tw==
+  /rc-virtual-list/3.2.6_react-dom@17.0.2+react@17.0.2:
     dependencies:
       classnames: 2.2.6
-      rc-resize-observer: 1.0.0_react-dom@17.0.1+react@17.0.1
-      rc-util: 5.8.1_react-dom@17.0.1+react@17.0.1
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      rc-resize-observer: 1.0.0_react-dom@17.0.2+react@17.0.2
+      rc-util: 5.9.8_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
     engines:
       node: '>=8.x'
@@ -7483,42 +7050,42 @@ packages:
   /rc/1.2.8:
     dependencies:
       deep-extend: 0.6.0
-      ini: 1.3.5
+      ini: 1.3.8
       minimist: 1.2.5
       strip-json-comments: 2.0.1
     dev: true
     hasBin: true
     resolution:
       integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  /react-dom/17.0.1_react@17.0.1:
+  /react-dom/17.0.2_react@17.0.2:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react: 17.0.1
-      scheduler: 0.20.1
+      react: 17.0.2
+      scheduler: 0.20.2
     peerDependencies:
-      react: 17.0.1
+      react: 17.0.2
     resolution:
-      integrity: sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
+      integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   /react-is/16.13.1:
     resolution:
       integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-  /react-is/17.0.1:
+  /react-is/17.0.2:
     dev: true
     resolution:
-      integrity: sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+      integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
   /react-lifecycles-compat/3.0.4:
     dev: true
     resolution:
       integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-  /react-live/2.2.3_react-dom@17.0.1+react@17.0.1:
+  /react-live/2.2.3_react-dom@17.0.2+react@17.0.2:
     dependencies:
       buble: 0.19.6
-      core-js: 2.6.11
+      core-js: 2.6.12
       dom-iterator: 1.0.0
-      prism-react-renderer: 1.1.1_react@17.0.1
+      prism-react-renderer: 1.2.0_react@17.0.2
       prop-types: 15.7.2
-      react-simple-code-editor: 0.10.0_react-dom@17.0.1+react@17.0.1
+      react-simple-code-editor: 0.10.0_react-dom@17.0.2+react@17.0.2
       unescape: 1.0.1
     dev: false
     engines:
@@ -7540,14 +7107,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
-  /react-router-dom/5.2.0_react@17.0.1:
+  /react-router-dom/5.2.0_react@17.0.2:
     dependencies:
-      '@babel/runtime': 7.10.5
+      '@babel/runtime': 7.13.10
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.7.2
-      react: 17.0.1
-      react-router: 5.2.0_react@17.0.1
+      react: 17.0.2
+      react-router: 5.2.0_react@17.0.2
       tiny-invariant: 1.1.0
       tiny-warning: 1.0.3
     dev: false
@@ -7555,16 +7122,16 @@ packages:
       react: '>=15'
     resolution:
       integrity: sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
-  /react-router/5.2.0_react@17.0.1:
+  /react-router/5.2.0_react@17.0.2:
     dependencies:
-      '@babel/runtime': 7.10.5
+      '@babel/runtime': 7.13.10
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
-      mini-create-react-context: 0.4.0_prop-types@15.7.2+react@17.0.1
+      mini-create-react-context: 0.4.1_prop-types@15.7.2+react@17.0.2
       path-to-regexp: 1.8.0
       prop-types: 15.7.2
-      react: 17.0.1
+      react: 17.0.2
       react-is: 16.13.1
       tiny-invariant: 1.1.0
       tiny-warning: 1.0.3
@@ -7573,22 +7140,22 @@ packages:
       react: '>=15'
     resolution:
       integrity: sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
-  /react-simple-code-editor/0.10.0_react-dom@17.0.1+react@17.0.1:
+  /react-simple-code-editor/0.10.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: false
     peerDependencies:
       react: ^16.0.0
       react-dom: ^16.0.0
     resolution:
       integrity: sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
-  /react-transition-group/2.9.0_react@17.0.1:
+  /react-transition-group/2.9.0_react@17.0.2:
     dependencies:
       dom-helpers: 3.4.0
       loose-envify: 1.4.0
       prop-types: 15.7.2
-      react: 17.0.1
+      react: 17.0.2
       react-lifecycles-compat: 3.0.4
     dev: true
     peerDependencies:
@@ -7596,25 +7163,14 @@ packages:
       react-dom: '>=15.0.0'
     resolution:
       integrity: sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
-  /react/17.0.1:
+  /react/17.0.2:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
-  /read-package-json/3.0.1:
-    dependencies:
-      glob: 7.1.6
-      json-parse-even-better-errors: 2.3.1
-      normalize-package-data: 3.0.1
-      npm-normalize-package-bin: 1.0.1
-    dev: true
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-aLcPqxovhJTVJcsnROuuzQvv6oziQx4zd3JvG0vGCL5MjTONUc4uJ90zCBC6R7W7oUKBNoR/F8pkyfVwlbxqng==
+      integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   /read-pkg-up/7.0.1:
     dependencies:
       find-up: 4.1.0
@@ -7683,7 +7239,7 @@ packages:
       regenerate: 1.4.2
       regenerate-unicode-properties: 8.2.0
       regjsgen: 0.5.2
-      regjsparser: 0.6.4
+      regjsparser: 0.6.9
       unicode-match-property-ecmascript: 1.0.4
       unicode-match-property-value-ecmascript: 1.2.0
     dev: false
@@ -7710,13 +7266,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==
-  /regjsparser/0.6.4:
+  /regjsparser/0.6.9:
     dependencies:
       jsesc: 0.5.0
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==
+      integrity: sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==
   /remark-footnotes/2.0.0:
     dev: false
     resolution:
@@ -7836,7 +7392,7 @@ packages:
       is-typedarray: 1.0.0
       isstream: 0.1.2
       json-stringify-safe: 5.0.1
-      mime-types: 2.1.27
+      mime-types: 2.1.29
       oauth-sign: 0.9.0
       performance-now: 2.1.0
       qs: 6.5.2
@@ -7896,12 +7452,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
-  /resolve/1.19.0:
-    dependencies:
-      is-core-module: 2.2.0
-      path-parse: 1.0.6
-    resolution:
-      integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
   /resolve/1.20.0:
     dependencies:
       is-core-module: 2.2.0
@@ -7948,10 +7498,10 @@ packages:
       import-cwd: 3.0.0
       p-queue: 6.6.2
       pify: 5.0.0
-      postcss-load-config: 3.0.0
+      postcss-load-config: 3.0.1
       postcss-modules: 4.0.0
       promise.series: 0.2.0
-      resolve: 1.19.0
+      resolve: 1.20.0
       rollup-pluginutils: 2.8.2
       safe-identifier: 0.4.2
       style-inject: 0.3.0
@@ -7966,32 +7516,34 @@ packages:
       estree-walker: 0.6.1
     resolution:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  /rollup/2.41.2:
+  /rollup/2.44.0:
     engines:
       node: '>=10.0.0'
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
     resolution:
-      integrity: sha512-6u8fJJXJx6fmvKrAC9DHYZgONvSkz8S9b/VFBjoQ6dkKdHyPpPbpqiNl2Bao9XBzDHpq672X6sGZ9G1ZBqAHMg==
+      integrity: sha512-rGSF4pLwvuaH/x4nAS+zP6UNn5YUDWf/TeEU5IoXSZKBbKRNTCI3qMnYXKZgrC0D2KzS2baiOZt1OlqhMu5rnQ==
   /rsvp/4.8.5:
     dev: true
     engines:
       node: 6.* || >= 7.*
     resolution:
       integrity: sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
-  /run-parallel/1.1.10:
+  /run-parallel/1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
     dev: true
     resolution:
-      integrity: sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
-  /rxjs/6.6.3:
+      integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+  /rxjs/6.6.7:
     dependencies:
       tslib: 1.14.1
     dev: true
     engines:
       npm: '>=2.0.0'
     resolution:
-      integrity: sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+      integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   /safe-buffer/5.1.2:
     resolution:
       integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -8017,7 +7569,7 @@ packages:
       '@cnakazawa/watch': 1.0.4
       anymatch: 2.0.0
       capture-exit: 2.0.0
-      exec-sh: 0.3.4
+      exec-sh: 0.3.6
       execa: 1.0.0
       fb-watchman: 2.0.1
       micromatch: 3.1.10
@@ -8049,18 +7601,18 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
-  /scheduler/0.20.1:
+  /scheduler/0.20.2:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
     resolution:
-      integrity: sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
-  /scroll-into-view-if-needed/2.2.27:
+      integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+  /scroll-into-view-if-needed/2.2.28:
     dependencies:
       compute-scroll-into-view: 1.0.17
     dev: true
     resolution:
-      integrity: sha512-BKiRstRm4u1bZvw+Wu9TxXhyMZ9fskb/9fbuSGuRzwHhlbKlDetL4dBdYaPfQbEFTttQmpkNtFH7sQpk4rZf9w==
+      integrity: sha512-8LuxJSuFVc92+0AdNv4QOxRL4Abeo1DgLnGNkn1XlaujPH/3cCFz3QI60r2VNu4obJJROzgnIUw5TKQkZvZI1w==
   /section-matter/1.0.0:
     dependencies:
       extend-shallow: 2.0.1
@@ -8078,7 +7630,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-  /semver/7.3.4:
+  /semver/7.3.5:
     dependencies:
       lru-cache: 6.0.0
     dev: true
@@ -8086,7 +7638,7 @@ packages:
       node: '>=10'
     hasBin: true
     resolution:
-      integrity: sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+      integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   /serve-handler/6.1.3:
     dependencies:
       bytes: 3.0.0
@@ -8183,7 +7735,7 @@ packages:
       integrity: sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
   /sirv/1.0.11:
     dependencies:
-      '@polka/url': 1.0.0-next.11
+      '@polka/url': 1.0.0-next.12
       mime: 2.5.2
       totalist: 1.1.0
     dev: true
@@ -8386,7 +7938,7 @@ packages:
   /string-hash/1.1.3:
     resolution:
       integrity: sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
-  /string-length/4.0.1:
+  /string-length/4.0.2:
     dependencies:
       char-regex: 1.0.2
       strip-ansi: 6.0.0
@@ -8394,7 +7946,7 @@ packages:
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==
+      integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==
   /string-width/2.1.1:
     dependencies:
       is-fullwidth-code-point: 2.0.0
@@ -8404,7 +7956,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
-  /string-width/4.2.0:
+  /string-width/4.2.2:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
@@ -8413,19 +7965,19 @@ packages:
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
-  /string.prototype.trimend/1.0.3:
+      integrity: sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
+  /string.prototype.trimend/1.0.4:
     dependencies:
-      call-bind: 1.0.0
+      call-bind: 1.0.2
       define-properties: 1.1.3
     resolution:
-      integrity: sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
-  /string.prototype.trimstart/1.0.3:
+      integrity: sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
+  /string.prototype.trimstart/1.0.4:
     dependencies:
-      call-bind: 1.0.0
+      call-bind: 1.0.2
       define-properties: 1.1.3
     resolution:
-      integrity: sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
+      integrity: sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
   /strip-ansi/4.0.0:
     dependencies:
       ansi-regex: 3.0.0
@@ -8499,18 +8051,18 @@ packages:
     dev: false
     resolution:
       integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
-  /styled-components/5.2.1_react-dom@17.0.1+react@17.0.1:
+  /styled-components/5.2.2_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      '@babel/helper-module-imports': 7.12.5
-      '@babel/traverse': 7.12.7_supports-color@5.5.0
+      '@babel/helper-module-imports': 7.13.12
+      '@babel/traverse': 7.13.13_supports-color@5.5.0
       '@emotion/is-prop-valid': 0.8.8
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 1.12.0_styled-components@5.2.1
+      babel-plugin-styled-components: 1.12.0_styled-components@5.2.2
       css-to-react-native: 3.0.0
       hoist-non-react-statics: 3.3.2
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       shallowequal: 1.1.0
       supports-color: 5.5.0
     dev: false
@@ -8521,10 +8073,10 @@ packages:
       react-dom: '>= 16.8.0'
       react-is: '>= 16.8.0'
     resolution:
-      integrity: sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==
+      integrity: sha512-ID8uckdZRF9tsaXP/G8GwoewS66XtIdHw05S88Fx/q0UHZup1eJ9JWcA7KEzoSt1uGgM4RCqA2JMw1iI1M5rTg==
   /stylehacks/4.0.3:
     dependencies:
-      browserslist: 4.16.0
+      browserslist: 4.16.3
       postcss: 7.0.35
       postcss-selector-parser: 3.1.2
     engines:
@@ -8579,7 +8131,7 @@ packages:
       csso: 4.2.0
       js-yaml: 3.14.1
       mkdirp: 0.5.5
-      object.values: 1.1.2
+      object.values: 1.1.3
       sax: 1.2.4
       stable: 0.1.8
       unquote: 1.1.1
@@ -8609,7 +8161,7 @@ packages:
       integrity: sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
   /terminal-link/2.1.1:
     dependencies:
-      ansi-escapes: 4.3.1
+      ansi-escapes: 4.3.2
       supports-hyperlinks: 2.1.0
     dev: true
     engines:
@@ -8761,7 +8313,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
-  /ts-jest/26.5.3_jest@26.6.3+typescript@4.2.3:
+  /ts-jest/26.5.4_jest@26.6.3+typescript@4.2.3:
     dependencies:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
@@ -8772,9 +8324,9 @@ packages:
       lodash: 4.17.21
       make-error: 1.3.6
       mkdirp: 1.0.4
-      semver: 7.3.4
+      semver: 7.3.5
       typescript: 4.2.3
-      yargs-parser: 20.2.6
+      yargs-parser: 20.2.7
     dev: true
     engines:
       node: '>= 10'
@@ -8783,7 +8335,7 @@ packages:
       jest: '>=26 <27'
       typescript: '>=3.8 <5.0'
     resolution:
-      integrity: sha512-nBiiFGNvtujdLryU7MiMQh1iPmnZ/QvOskBbD2kURiI1MwqvxlxNnaAB/z9TbslMqCsSbu5BXvSSQPc5tvHGeA==
+      integrity: sha512-I5Qsddo+VTm94SukBJ4cPimOoFZsYTeElR2xy6H2TOVs+NsvgYglW8KuQgKoApOKuaU/Ix/vrF9ebFZlb5D2Pg==
   /tslib/1.14.1:
     dev: true
     resolution:
@@ -8812,12 +8364,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-  /type-fest/0.11.0:
+  /type-fest/0.21.3:
     dev: true
     engines:
-      node: '>=8'
+      node: '>=10'
     resolution:
-      integrity: sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+      integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
   /type-fest/0.6.0:
     engines:
       node: '>=8'
@@ -8841,6 +8393,14 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+  /unbox-primitive/1.0.1:
+    dependencies:
+      function-bind: 1.1.1
+      has-bigints: 1.0.1
+      has-symbols: 1.0.2
+      which-boxed-primitive: 1.0.2
+    resolution:
+      integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
   /unescape/1.0.1:
     dependencies:
       extend-shallow: 2.0.1
@@ -8919,11 +8479,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==
-  /unist-util-is/4.0.4:
-    resolution:
-      integrity: sha512-3dF39j/u423v4BBQrk1AQ2Ve1FxY5W3JKwXxVFzBODQ6WEvccguhgp802qQLKSnxPODE6WuRZtV+ohlUg4meBA==
   /unist-util-is/4.1.0:
-    dev: true
     resolution:
       integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==
   /unist-util-position/3.1.0:
@@ -8938,7 +8494,7 @@ packages:
       integrity: sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==
   /unist-util-remove/2.0.1:
     dependencies:
-      unist-util-is: 4.0.4
+      unist-util-is: 4.1.0
     dev: false
     resolution:
       integrity: sha512-YtuetK6o16CMfG+0u4nndsWpujgsHDHHLyE0yGpJLLn5xSjKeyGyzEBOI2XbmoUHCYabmNgX52uxlWoQhcvR7Q==
@@ -8951,13 +8507,13 @@ packages:
   /unist-util-visit-parents/3.1.1:
     dependencies:
       '@types/unist': 2.0.3
-      unist-util-is: 4.0.4
+      unist-util-is: 4.1.0
     resolution:
       integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==
   /unist-util-visit/2.0.3:
     dependencies:
       '@types/unist': 2.0.3
-      unist-util-is: 4.0.4
+      unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
     resolution:
       integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==
@@ -8991,12 +8547,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==
-  /uri-js/4.2.2:
+  /uri-js/4.4.1:
     dependencies:
       punycode: 2.1.1
     dev: true
     resolution:
-      integrity: sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+      integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   /urix/0.1.0:
     deprecated: Please see https://github.com/lydell/urix#deprecated
     dev: true
@@ -9014,9 +8570,9 @@ packages:
   /util.promisify/1.0.1:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.7
-      has-symbols: 1.0.1
-      object.getownpropertydescriptors: 2.1.1
+      es-abstract: 1.18.0
+      has-symbols: 1.0.2
+      object.getownpropertydescriptors: 2.1.2
     resolution:
       integrity: sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==
   /uuid/3.4.0:
@@ -9030,7 +8586,7 @@ packages:
     optional: true
     resolution:
       integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-  /v8-to-istanbul/7.1.0:
+  /v8-to-istanbul/7.1.1:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       convert-source-map: 1.7.0
@@ -9039,7 +8595,7 @@ packages:
     engines:
       node: '>=10.10.0'
     resolution:
-      integrity: sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==
+      integrity: sha512-p0BB09E5FRjx0ELN6RgusIPsSPhtgexSRcKETybEs6IGOTXJSZqfwxp7r//55nnu0f1AxltY5VvdVqy2vZf9AA==
   /validate-npm-package-license/3.0.4:
     dependencies:
       spdx-correct: 3.1.1
@@ -9089,34 +8645,34 @@ packages:
     dev: false
     resolution:
       integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==
-  /vite-plugin-mdx/3.2.2_vite@2.0.5:
+  /vite-plugin-mdx/3.2.2_vite@2.1.4:
     dependencies:
       esbuild: 0.8.57
-      find-dependency: 1.3.0
-      vite: 2.0.5
+      find-dependency: 1.3.3
+      vite: 2.1.4
     dev: true
     peerDependencies:
       '@mdx-js/mdx': '*'
       vite: '*'
     resolution:
       integrity: sha512-yNXsIDlQUldZBdtBXFmPFGINj1x4IJmbgg+i2j8/FU1XfwKCMr15v/ArUOYyGldsKw/Fq7DVn2ASwSyICphwgQ==
-  /vite-plugin-react/4.0.1_vite@2.0.5:
+  /vite-plugin-react/4.0.1_vite@2.1.4:
     dependencies:
-      '@babel/core': 7.12.10
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.12.10
+      '@babel/core': 7.13.14
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.13.14
       react-refresh: 0.8.3
-      vite: 2.0.5
+      vite: 2.1.4
     dev: true
     peerDependencies:
       vite: '>=1.0.0-rc.13'
     resolution:
       integrity: sha512-liDo/wxTcy2E5cptwsAUZIC0F4flxWkmcPOJdhKCzJIC9XguWCCJimzziTQRmHuqIPawmQNE8PJb8+RlGzNxOA==
-  /vite/2.0.5:
+  /vite/2.1.4:
     dependencies:
       esbuild: 0.8.57
       postcss: 8.2.8
       resolve: 1.20.0
-      rollup: 2.41.2
+      rollup: 2.44.0
     dev: true
     engines:
       node: '>=12.0.0'
@@ -9124,7 +8680,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     resolution:
-      integrity: sha512-QTgEDbq1WsTtr6j+++ewjhBFEk6c8v0xz4fb/OWJQKNYU8ZZtphOshwOqAlnarSstPBtWCBR0tsugXx6ajfoUg==
+      integrity: sha512-j/p0RZQvNY/auSPfazsDfo1PHtFp8ktwXPbzI6NqplzHcR3Cn/dfQWiMxL6zp8j9IWdcJP1Zfms7mxruBhStJw==
   /vlq/1.0.1:
     dev: false
     resolution:
@@ -9181,16 +8737,25 @@ packages:
     dev: true
     resolution:
       integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
-  /whatwg-url/8.4.0:
+  /whatwg-url/8.5.0:
     dependencies:
-      lodash.sortby: 4.7.0
+      lodash: 4.17.21
       tr46: 2.0.2
       webidl-conversions: 6.1.0
     dev: true
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==
+      integrity: sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==
+  /which-boxed-primitive/1.0.2:
+    dependencies:
+      is-bigint: 1.0.1
+      is-boolean-object: 1.1.0
+      is-number-object: 1.0.4
+      is-string: 1.0.5
+      is-symbol: 1.0.3
+    resolution:
+      integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
   /which-module/2.0.0:
     dev: true
     resolution:
@@ -9228,7 +8793,7 @@ packages:
   /wrap-ansi/6.2.0:
     dependencies:
       ansi-styles: 4.3.0
-      string-width: 4.2.0
+      string-width: 4.2.2
       strip-ansi: 6.0.0
     dev: true
     engines:
@@ -9238,7 +8803,7 @@ packages:
   /wrap-ansi/7.0.0:
     dependencies:
       ansi-styles: 4.3.0
-      string-width: 4.2.0
+      string-width: 4.2.2
       strip-ansi: 6.0.0
     dev: true
     engines:
@@ -9313,11 +8878,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-  /yaml/1.10.0:
+  /yaml/1.10.2:
     engines:
       node: '>= 6'
     resolution:
-      integrity: sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
+      integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
   /yargs-parser/18.1.3:
     dependencies:
       camelcase: 5.3.1
@@ -9327,12 +8892,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
-  /yargs-parser/20.2.6:
+  /yargs-parser/20.2.7:
     dev: true
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==
+      integrity: sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
   /yargs/15.4.1:
     dependencies:
       cliui: 6.0.0
@@ -9342,7 +8907,7 @@ packages:
       require-directory: 2.1.1
       require-main-filename: 2.0.0
       set-blocking: 2.0.0
-      string-width: 4.2.0
+      string-width: 4.2.2
       which-module: 2.0.0
       y18n: 4.0.1
       yargs-parser: 18.1.3
@@ -9357,9 +8922,9 @@ packages:
       escalade: 3.1.1
       get-caller-file: 2.0.5
       require-directory: 2.1.1
-      string-width: 4.2.0
+      string-width: 4.2.2
       y18n: 5.0.5
-      yargs-parser: 20.2.6
+      yargs-parser: 20.2.7
     dev: true
     engines:
       node: '>=10'


### PR DESCRIPTION
Re-implement the findPages API using proxy to track the file-data association.

- Users can mutate page data objects. If they do that within the fileHandler, react-pages can track the file-data association. So that when the file is unlinked, react-pages can delete all associated data with it automatically.
- This implementation doesn't use a context pointer(previous `currentFile`) to know which is the currentFile. Instead, it create updateAPI with context info(file), and pass it to fileHandler. https://github.com/vitejs/vite-plugin-react-pages/pull/19/files#diff-c6eac2832f06bfdd90961b8e261a9aba3a584f50cb7bc444fa230eeae11e3756R91

Sample user code: 
```ts
findPages: (root, { watchFiles }) =>
  watchFiles(root, globs, (file, {getRuntimeData, getStaticData}) => {
    const data = getRuntimeData('pageId')
    const staticData = getStaticData('pageId')

    // Edit to your heart's content.
    data.contributorList = ['...']
    staticData.title ||= 'Default title'
  })
```

Fix: https://github.com/vitejs/vite-plugin-react-pages/issues/18