### PR TITLE
Change assets folder from '_assets' to 'assets'

### DIFF
--- a/packages/react-pages/src/node/static-site-generation/index.ts
+++ b/packages/react-pages/src/node/static-site-generation/index.ts
@@ -72,7 +72,7 @@ export async function ssrBuild(
         input: path.join(CLIENT_PATH, 'ssr', 'clientRender.js'),
         preserveEntrySignatures: 'allow-extension',
       },
-      assetsDir: '_assets',
+      assetsDir: 'assets',
       outDir: clientOutDir,
     },
   })


### PR DESCRIPTION
The folder with the leading underline isn't accessible at GitHub Pages.