### PR TITLE
Migrate plugin-react-refresh to plugin-react

### DIFF
--- a/doc-site/package.json
+++ b/doc-site/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.1.4",
     "gh-pages": "^3.1.0",
     "serve": "^12.0.1",
     "vite": "^2.5.6",

--- a/doc-site/pages/upgrade-from-v2$.mdx
+++ b/doc-site/pages/upgrade-from-v2$.mdx
@@ -13,7 +13,7 @@ Upgrade these package versions:
 ```json
 {
   "devDependencies": {
-    "@vitejs/plugin-react-refresh": "^1.3.1",
+    "@vitejs/plugin-react": "^1.1.4",
     "vite": "^2.5.6",
     "vite-plugin-mdx": "^3.3.1",
     "vite-plugin-react-pages": "^3.0.0",

--- a/doc-site/vite.config.ts
+++ b/doc-site/vite.config.ts
@@ -1,12 +1,12 @@
 import type { UserConfig } from 'vite'
 
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
-  plugins: [reactRefresh(), mdx(), pages()],
+  plugins: [react(), mdx(), pages()],
   base:
     process.env.GITHUB_PAGES_DEPLOY === 'true'
       ? '/vite-plugin-react-pages'

--- a/packages/create-project/template-app/package.json
+++ b/packages/create-project/template-app/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^14.14.37",
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.1.4",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-plugin-mdx": "^3.5.6",

--- a/packages/create-project/template-app/vite.config.ts
+++ b/packages/create-project/template-app/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages from 'vite-plugin-react-pages'
 
 export default defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/create-project/template-lib-monorepo/packages/demos/package.json
+++ b/packages/create-project/template-lib-monorepo/packages/demos/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^14.14.37",
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.1.4",
     "globby": "^11.0.2",
     "my-button": "*",
     "my-card": "*",

--- a/packages/create-project/template-lib-monorepo/packages/demos/vite.config.ts
+++ b/packages/create-project/template-lib-monorepo/packages/demos/vite.config.ts
@@ -1,14 +1,14 @@
 import type { UserConfig } from 'vite'
 import * as path from 'path'
 
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages, { DefaultPageStrategy } from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/create-project/template-lib/docs/vite.config.ts
+++ b/packages/create-project/template-lib/docs/vite.config.ts
@@ -1,13 +1,13 @@
 import type { UserConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages, { DefaultPageStrategy } from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/create-project/template-lib/package.json
+++ b/packages/create-project/template-lib/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^14.14.37",
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.1.4",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-plugin-mdx": "^3.5.6",

--- a/packages/playground/basic/package.json
+++ b/packages/playground/basic/package.json
@@ -20,7 +20,7 @@
     "@mdx-js/mdx": "^1.6.22",
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.1.4",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-plugin-mdx": "^3.5.6",

--- a/packages/playground/basic/vite.config.ts
+++ b/packages/playground/basic/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages from 'vite-plugin-react-pages'
 
 module.exports = defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/playground/custom-find-pages/package.json
+++ b/packages/playground/custom-find-pages/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.1.4",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-pages-theme-basic": "workspace:*",

--- a/packages/playground/custom-find-pages/vite.config.ts
+++ b/packages/playground/custom-find-pages/vite.config.ts
@@ -1,13 +1,13 @@
 import type { UserConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages, { DefaultPageStrategy } from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/playground/custom-find-pages2/package.json
+++ b/packages/playground/custom-find-pages2/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.1.4",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-pages-theme-basic": "workspace:*",

--- a/packages/playground/custom-find-pages2/pages/vite.config.ts
+++ b/packages/playground/custom-find-pages2/pages/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages, {
   PageStrategy,
@@ -11,7 +11,7 @@ import pages, {
 
 export default defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: __dirname,

--- a/packages/playground/lib-monorepo/packages/demos/package.json
+++ b/packages/playground/lib-monorepo/packages/demos/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.1.4",
     "globby": "^11.0.2",
     "playground-button": "*",
     "playground-card": "*",

--- a/packages/playground/lib-monorepo/packages/demos/vite.demos.ts
+++ b/packages/playground/lib-monorepo/packages/demos/vite.demos.ts
@@ -1,13 +1,13 @@
 import type { UserConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages, { DefaultPageStrategy } from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/playground/use-theme-doc/package.json
+++ b/packages/playground/use-theme-doc/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.1.4",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-pages-theme-doc": "workspace:*",

--- a/packages/playground/use-theme-doc/vite.config.ts
+++ b/packages/playground/use-theme-doc/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages from 'vite-plugin-react-pages'
 
 module.exports = defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/playground/use-theme/package.json
+++ b/packages/playground/use-theme/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.1.4",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-pages-theme-basic": "workspace:*",

--- a/packages/playground/use-theme/vite.config.ts
+++ b/packages/playground/use-theme/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages from 'vite-plugin-react-pages'
 
 module.exports = defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.1.4
       gh-pages: ^3.1.0
       react: ^17.0.1
       react-dom: ^17.0.1
@@ -57,7 +57,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.1.4
       gh-pages: 3.2.3
       serve: 12.0.1
       vite: 2.7.7
@@ -80,7 +80,7 @@ importers:
       '@types/node': ^14.14.37
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.1.4
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -99,7 +99,7 @@ importers:
       '@types/node': 14.18.3
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.1.4
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-doc: link:../../theme-doc
@@ -113,7 +113,7 @@ importers:
       '@types/node': ^14.14.37
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.1.4
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -132,7 +132,7 @@ importers:
       '@types/node': 14.18.3
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.1.4
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-doc: link:../../theme-doc
@@ -169,7 +169,7 @@ importers:
       '@types/node': ^14.14.37
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.1.4
       globby: ^11.0.2
       my-button: '*'
       my-card: '*'
@@ -191,7 +191,7 @@ importers:
       '@types/node': 14.18.3
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.1.4
       globby: 11.0.4
       my-button: link:../button
       my-card: link:../card
@@ -212,7 +212,7 @@ importers:
       '@mdx-js/mdx': ^1.6.22
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.1.4
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -228,7 +228,7 @@ importers:
       '@mdx-js/mdx': 1.6.22
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.1.4
       serve: 12.0.1
       vite: 2.7.7
       vite-plugin-mdx: 3.5.10_@mdx-js+mdx@1.6.22+vite@2.7.7
@@ -238,7 +238,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.1.4
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -254,7 +254,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.1.4
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-basic: link:../../theme-basic
@@ -265,7 +265,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.1.4
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -281,7 +281,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.1.4
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-basic: link:../../theme-basic
@@ -315,7 +315,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.1.4
       globby: ^11.0.2
       playground-button: '*'
       playground-card: '*'
@@ -334,7 +334,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.1.4
       globby: 11.0.4
       playground-button: link:../button
       playground-card: link:../card
@@ -348,7 +348,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.1.4
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -364,7 +364,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.1.4
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-basic: link:../../theme-basic
@@ -375,7 +375,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.1.4
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -391,7 +391,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.1.4
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-doc: link:../../theme-doc
@@ -1273,6 +1273,16 @@ packages:
     dependencies:
       '@babel/helper-plugin-utils': 7.16.5
 
+  /@babel/plugin-syntax-jsx/7.16.5_@babel+core@7.16.5:
+    resolution: {integrity: sha512-42OGssv9NPk4QHKVgIHlzeLgPOW5rGgfV5jzG90AhcXXIv6hu/eqj63w4VgvRxdvZY3AlYeDgPiSJ3BqAd1Y6Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.5
+      '@babel/helper-plugin-utils': 7.16.5
+    dev: true
+
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
@@ -1690,6 +1700,16 @@ packages:
     dependencies:
       '@babel/plugin-transform-react-jsx': 7.16.5
 
+  /@babel/plugin-transform-react-jsx-development/7.16.5_@babel+core@7.16.5:
+    resolution: {integrity: sha512-uQSLacMZSGLCxOw20dzo1dmLlKkd+DsayoV54q3MHXhbqgPzoiGerZQgNPl/Ro8/OcXV2ugfnkx+rxdS0sN5Uw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.5
+      '@babel/plugin-transform-react-jsx': 7.16.5_@babel+core@7.16.5
+    dev: true
+
   /@babel/plugin-transform-react-jsx-self/7.16.5_@babel+core@7.16.5:
     resolution: {integrity: sha512-fvwq+jir1Vn4f5oBS0H/J/gD5CneTD53MHs+NMjlHcha4Sq35fwxI5RtmJGEBXO+M93f/eeD9cAhRPhmLyJiVw==}
     engines: {node: '>=6.9.0'}
@@ -1721,6 +1741,20 @@ packages:
       '@babel/helper-plugin-utils': 7.16.5
       '@babel/plugin-syntax-jsx': 7.16.5
       '@babel/types': 7.16.0
+
+  /@babel/plugin-transform-react-jsx/7.16.5_@babel+core@7.16.5:
+    resolution: {integrity: sha512-+arLIz1d7kmwX0fKxTxbnoeG85ONSnLpvdODa4P3pc1sS7CV1hfmtYWufkW/oYsPnkDrEeQFxhUWcFnrXW7jQQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.16.5
+      '@babel/helper-annotate-as-pure': 7.16.0
+      '@babel/helper-module-imports': 7.16.0
+      '@babel/helper-plugin-utils': 7.16.5
+      '@babel/plugin-syntax-jsx': 7.16.5_@babel+core@7.16.5
+      '@babel/types': 7.16.0
+    dev: true
 
   /@babel/plugin-transform-react-pure-annotations/7.16.5:
     resolution: {integrity: sha512-0nYU30hCxnCVCbRjSy9ahlhWZ2Sn6khbY4FqR91W+2RbSqkWEbVu2gXh45EqNy4Bq7sRU+H4i0/6YKwOSzh16A==}
@@ -2692,15 +2726,18 @@ packages:
     dev: true
     optional: true
 
-  /@vitejs/plugin-react-refresh/1.3.6:
-    resolution: {integrity: sha512-iNR/UqhUOmFFxiezt0em9CgmiJBdWR+5jGxB2FihaoJfqGt76kiwaKoVOJVU5NYcDWMdN06LbyN2VIGIoYdsEA==}
+  /@vitejs/plugin-react/1.1.4:
+    resolution: {integrity: sha512-cMUBDonNY8PPeHWjIrYKbRn6bLSunh/Ixo2XLLBd3DM0uYBZft+c+04zkGhhN1lAwvoRKJ2FdtvhGhPgViHc6w==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@babel/core': 7.16.5
+      '@babel/plugin-transform-react-jsx': 7.16.5_@babel+core@7.16.5
+      '@babel/plugin-transform-react-jsx-development': 7.16.5_@babel+core@7.16.5
       '@babel/plugin-transform-react-jsx-self': 7.16.5_@babel+core@7.16.5
       '@babel/plugin-transform-react-jsx-source': 7.16.5_@babel+core@7.16.5
       '@rollup/pluginutils': 4.1.2
-      react-refresh: 0.10.0
+      react-refresh: 0.11.0
+      resolve: 1.20.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7566,8 +7603,8 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: true
 
-  /react-refresh/0.10.0:
-    resolution: {integrity: sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==}
+  /react-refresh/0.11.0:
+    resolution: {integrity: sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==}
     engines: {node: '>=0.10.0'}
     dev: true
 


### PR DESCRIPTION
`@vitejs/plugin-react-refresh` is now renamed to `@vitejs/plugin-react`

https://vitejs.dev/guide/migration.html#react-support
> React Fast Refresh support is now provided via @vitejs/plugin-react.