### PR TITLE
chore: replace the deprecated vite-plugin-react-refresh to vite-plugin-react

### DIFF
--- a/doc-site/package.json
+++ b/doc-site/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.2.0",
     "gh-pages": "^3.1.0",
     "serve": "^12.0.1",
     "vite": "^2.5.6",

--- a/doc-site/pages/upgrade-from-v2$.mdx
+++ b/doc-site/pages/upgrade-from-v2$.mdx
@@ -13,7 +13,7 @@ Upgrade these package versions:
 ```json
 {
   "devDependencies": {
-    "@vitejs/plugin-react-refresh": "^1.3.1",
+    "@vitejs/plugin-react": "^1.2.0",
     "vite": "^2.5.6",
     "vite-plugin-mdx": "^3.3.1",
     "vite-plugin-react-pages": "^3.0.0",

--- a/doc-site/vite.config.ts
+++ b/doc-site/vite.config.ts
@@ -1,12 +1,12 @@
 import type { UserConfig } from 'vite'
 
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
-  plugins: [reactRefresh(), mdx(), pages()],
+  plugins: [react(), mdx(), pages()],
   base:
     process.env.GITHUB_PAGES_DEPLOY === 'true'
       ? '/vite-plugin-react-pages'

--- a/packages/create-project/template-app/package.json
+++ b/packages/create-project/template-app/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^14.14.37",
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.2.0",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-plugin-mdx": "^3.5.6",

--- a/packages/create-project/template-app/vite.config.ts
+++ b/packages/create-project/template-app/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages from 'vite-plugin-react-pages'
 
 export default defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/create-project/template-lib-monorepo/packages/demos/package.json
+++ b/packages/create-project/template-lib-monorepo/packages/demos/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^14.14.37",
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.2.0",
     "globby": "^11.0.2",
     "my-button": "*",
     "my-card": "*",

--- a/packages/create-project/template-lib-monorepo/packages/demos/vite.config.ts
+++ b/packages/create-project/template-lib-monorepo/packages/demos/vite.config.ts
@@ -1,14 +1,14 @@
 import type { UserConfig } from 'vite'
 import * as path from 'path'
 
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages, { DefaultPageStrategy } from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/create-project/template-lib/docs/vite.config.ts
+++ b/packages/create-project/template-lib/docs/vite.config.ts
@@ -1,13 +1,13 @@
 import type { UserConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages, { DefaultPageStrategy } from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/create-project/template-lib/package.json
+++ b/packages/create-project/template-lib/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^14.14.37",
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.2.0",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-plugin-mdx": "^3.5.6",

--- a/packages/playground/basic/package.json
+++ b/packages/playground/basic/package.json
@@ -20,7 +20,7 @@
     "@mdx-js/mdx": "^1.6.22",
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.2.0",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-plugin-mdx": "^3.5.6",

--- a/packages/playground/basic/vite.config.ts
+++ b/packages/playground/basic/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages from 'vite-plugin-react-pages'
 
 module.exports = defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/playground/custom-find-pages/package.json
+++ b/packages/playground/custom-find-pages/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.2.0",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-pages-theme-basic": "workspace:*",

--- a/packages/playground/custom-find-pages/vite.config.ts
+++ b/packages/playground/custom-find-pages/vite.config.ts
@@ -1,13 +1,13 @@
 import type { UserConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages, { DefaultPageStrategy } from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/playground/custom-find-pages2/package.json
+++ b/packages/playground/custom-find-pages2/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.2.0",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-pages-theme-basic": "workspace:*",

--- a/packages/playground/custom-find-pages2/pages/vite.config.ts
+++ b/packages/playground/custom-find-pages2/pages/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages, {
   PageStrategy,
@@ -11,7 +11,7 @@ import pages, {
 
 export default defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: __dirname,

--- a/packages/playground/lib-monorepo/packages/demos/package.json
+++ b/packages/playground/lib-monorepo/packages/demos/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.2.0",
     "globby": "^11.0.2",
     "playground-button": "*",
     "playground-card": "*",

--- a/packages/playground/lib-monorepo/packages/demos/vite.demos.ts
+++ b/packages/playground/lib-monorepo/packages/demos/vite.demos.ts
@@ -1,13 +1,13 @@
 import type { UserConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages, { DefaultPageStrategy } from 'vite-plugin-react-pages'
 
 module.exports = {
   jsx: 'react',
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/playground/use-theme-doc/package.json
+++ b/packages/playground/use-theme-doc/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.2.0",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-pages-theme-doc": "workspace:*",

--- a/packages/playground/use-theme-doc/vite.config.ts
+++ b/packages/playground/use-theme-doc/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages from 'vite-plugin-react-pages'
 
 module.exports = defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/packages/playground/use-theme/package.json
+++ b/packages/playground/use-theme/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@vitejs/plugin-react-refresh": "^1.3.3",
+    "@vitejs/plugin-react": "^1.2.0",
     "serve": "^12.0.1",
     "vite": "^2.5.6",
     "vite-pages-theme-basic": "workspace:*",

--- a/packages/playground/use-theme/vite.config.ts
+++ b/packages/playground/use-theme/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import * as path from 'path'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 import mdx from 'vite-plugin-mdx'
 import pages from 'vite-plugin-react-pages'
 
 module.exports = defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     mdx(),
     pages({
       pagesDir: path.join(__dirname, 'pages'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.2.0
       gh-pages: ^3.1.0
       react: ^17.0.1
       react-dom: ^17.0.1
@@ -57,7 +57,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.2.0
       gh-pages: 3.2.3
       serve: 12.0.1
       vite: 2.7.7
@@ -80,7 +80,7 @@ importers:
       '@types/node': ^14.14.37
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -99,7 +99,7 @@ importers:
       '@types/node': 14.18.3
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.2.0
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-doc: link:../../theme-doc
@@ -113,7 +113,7 @@ importers:
       '@types/node': ^14.14.37
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -132,7 +132,7 @@ importers:
       '@types/node': 14.18.3
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.2.0
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-doc: link:../../theme-doc
@@ -169,7 +169,7 @@ importers:
       '@types/node': ^14.14.37
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.2.0
       globby: ^11.0.2
       my-button: '*'
       my-card: '*'
@@ -191,7 +191,7 @@ importers:
       '@types/node': 14.18.3
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.2.0
       globby: 11.0.4
       my-button: link:../button
       my-card: link:../card
@@ -212,7 +212,7 @@ importers:
       '@mdx-js/mdx': ^1.6.22
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -228,7 +228,7 @@ importers:
       '@mdx-js/mdx': 1.6.22
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.2.0
       serve: 12.0.1
       vite: 2.7.7
       vite-plugin-mdx: 3.5.10_@mdx-js+mdx@1.6.22+vite@2.7.7
@@ -238,7 +238,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -254,7 +254,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.2.0
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-basic: link:../../theme-basic
@@ -265,7 +265,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -281,7 +281,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.2.0
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-basic: link:../../theme-basic
@@ -315,7 +315,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.2.0
       globby: ^11.0.2
       playground-button: '*'
       playground-card: '*'
@@ -334,7 +334,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.2.0
       globby: 11.0.4
       playground-button: link:../button
       playground-card: link:../card
@@ -348,7 +348,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -364,7 +364,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.2.0
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-basic: link:../../theme-basic
@@ -375,7 +375,7 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       '@types/react-router-dom': ^5.1.7
-      '@vitejs/plugin-react-refresh': ^1.3.3
+      '@vitejs/plugin-react': ^1.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
@@ -391,7 +391,7 @@ importers:
     devDependencies:
       '@types/react': 17.0.38
       '@types/react-router-dom': 5.3.2
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vitejs/plugin-react': 1.2.0
       serve: 12.0.1
       vite: 2.7.7
       vite-pages-theme-doc: link:../../theme-doc
@@ -617,6 +617,13 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /@ampproject/remapping/2.1.1:
+    resolution: {integrity: sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.4
+    dev: true
+
   /@ant-design/colors/6.0.0:
     resolution: {integrity: sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==}
     dependencies:
@@ -658,6 +665,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.16.0
+
+  /@babel/code-frame/7.16.7:
+    resolution: {integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.16.10
+    dev: true
 
   /@babel/compat-data/7.16.4:
     resolution: {integrity: sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==}
@@ -711,6 +725,29 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/core/7.17.4:
+    resolution: {integrity: sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.1.1
+      '@babel/code-frame': 7.16.7
+      '@babel/generator': 7.17.3
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.17.4
+      '@babel/helper-module-transforms': 7.16.7
+      '@babel/helpers': 7.17.2
+      '@babel/parser': 7.17.3
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+      convert-source-map: 1.8.0
+      debug: 4.3.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.0
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/generator/7.16.5:
     resolution: {integrity: sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==}
     engines: {node: '>=6.9.0'}
@@ -719,11 +756,27 @@ packages:
       jsesc: 2.5.2
       source-map: 0.5.7
 
+  /@babel/generator/7.17.3:
+    resolution: {integrity: sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.17.0
+      jsesc: 2.5.2
+      source-map: 0.5.7
+    dev: true
+
   /@babel/helper-annotate-as-pure/7.16.0:
     resolution: {integrity: sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.0
+
+  /@babel/helper-annotate-as-pure/7.16.7:
+    resolution: {integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.16.5:
     resolution: {integrity: sha512-3JEA9G5dmmnIWdzaT9d0NmFRgYnWUThLsDaL7982H0XqqWr56lRrsmwheXFMjR+TMl7QMBb6mzy9kvgr1lRLUA==}
@@ -754,6 +807,19 @@ packages:
       '@babel/compat-data': 7.16.4
       '@babel/core': 7.16.5
       '@babel/helper-validator-option': 7.14.5
+      browserslist: 4.19.1
+      semver: 6.3.0
+    dev: true
+
+  /@babel/helper-compilation-targets/7.16.7_@babel+core@7.17.4:
+    resolution: {integrity: sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.16.4
+      '@babel/core': 7.17.4
+      '@babel/helper-validator-option': 7.16.7
       browserslist: 4.19.1
       semver: 6.3.0
     dev: true
@@ -807,6 +873,13 @@ packages:
     dependencies:
       '@babel/types': 7.16.0
 
+  /@babel/helper-environment-visitor/7.16.7:
+    resolution: {integrity: sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
+
   /@babel/helper-explode-assignable-expression/7.16.0:
     resolution: {integrity: sha512-Hk2SLxC9ZbcOhLpg/yMznzJ11W++lg5GMbxt1ev6TXUiJB0N42KPC+7w8a+eWGuqDnUYuwStJoZHM7RgmIOaGQ==}
     engines: {node: '>=6.9.0'}
@@ -822,17 +895,40 @@ packages:
       '@babel/template': 7.16.0
       '@babel/types': 7.16.0
 
+  /@babel/helper-function-name/7.16.7:
+    resolution: {integrity: sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-get-function-arity': 7.16.7
+      '@babel/template': 7.16.7
+      '@babel/types': 7.17.0
+    dev: true
+
   /@babel/helper-get-function-arity/7.16.0:
     resolution: {integrity: sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.0
 
+  /@babel/helper-get-function-arity/7.16.7:
+    resolution: {integrity: sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
+
   /@babel/helper-hoist-variables/7.16.0:
     resolution: {integrity: sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.0
+
+  /@babel/helper-hoist-variables/7.16.7:
+    resolution: {integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
 
   /@babel/helper-member-expression-to-functions/7.16.5:
     resolution: {integrity: sha512-7fecSXq7ZrLE+TWshbGT+HyCLkxloWNhTbU2QM1NTI/tDqyf0oZiMcEfYtDuUDCo528EOlt39G1rftea4bRZIw==}
@@ -845,6 +941,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.16.0
+
+  /@babel/helper-module-imports/7.16.7:
+    resolution: {integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
 
   /@babel/helper-module-transforms/7.16.5:
     resolution: {integrity: sha512-CkvMxgV4ZyyioElFwcuWnDCcNIeyqTkCm9BxXZi73RR1ozqlpboqsbGUNvRTflgZtFbbJ1v5Emvm+lkjMYY/LQ==}
@@ -862,6 +965,22 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-module-transforms/7.16.7:
+    resolution: {integrity: sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.16.7
+      '@babel/helper-module-imports': 7.16.7
+      '@babel/helper-simple-access': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+      '@babel/helper-validator-identifier': 7.16.7
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helper-optimise-call-expression/7.16.0:
     resolution: {integrity: sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==}
     engines: {node: '>=6.9.0'}
@@ -875,6 +994,11 @@ packages:
   /@babel/helper-plugin-utils/7.16.5:
     resolution: {integrity: sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ==}
     engines: {node: '>=6.9.0'}
+
+  /@babel/helper-plugin-utils/7.16.7:
+    resolution: {integrity: sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==}
+    engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-remap-async-to-generator/7.16.5:
     resolution: {integrity: sha512-X+aAJldyxrOmN9v3FKp+Hu1NO69VWgYgDGq6YDykwRPzxs5f2N+X988CBXS7EQahDU+Vpet5QYMqLk+nsp+Qxw==}
@@ -906,6 +1030,13 @@ packages:
       '@babel/types': 7.16.0
     dev: true
 
+  /@babel/helper-simple-access/7.16.7:
+    resolution: {integrity: sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
+
   /@babel/helper-skip-transparent-expression-wrappers/7.16.0:
     resolution: {integrity: sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==}
     engines: {node: '>=6.9.0'}
@@ -919,13 +1050,30 @@ packages:
     dependencies:
       '@babel/types': 7.16.0
 
+  /@babel/helper-split-export-declaration/7.16.7:
+    resolution: {integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.17.0
+    dev: true
+
   /@babel/helper-validator-identifier/7.15.7:
     resolution: {integrity: sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-validator-identifier/7.16.7:
+    resolution: {integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-option/7.14.5:
     resolution: {integrity: sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==}
     engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-option/7.16.7:
+    resolution: {integrity: sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-wrap-function/7.16.5:
     resolution: {integrity: sha512-2J2pmLBqUqVdJw78U0KPNdeE2qeuIyKoG4mKV7wAq3mc4jJG282UgjZw4ZYDnqiWQuS3Y3IYdF/AQ6CpyBV3VA==}
@@ -950,6 +1098,17 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helpers/7.17.2:
+    resolution: {integrity: sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/highlight/7.16.0:
     resolution: {integrity: sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==}
     engines: {node: '>=6.9.0'}
@@ -958,10 +1117,25 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
+  /@babel/highlight/7.16.10:
+    resolution: {integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.16.7
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
   /@babel/parser/7.16.6:
     resolution: {integrity: sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  /@babel/parser/7.17.3:
+    resolution: {integrity: sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.16.2:
     resolution: {integrity: sha512-h37CvpLSf8gb2lIJ2CgC3t+EjFbi0t8qS7LCS1xcJIlEXE4czlofwaW7W1HA8zpgOCzI9C1nmoqNR1zWkk0pQg==}
@@ -1272,6 +1446,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/helper-plugin-utils': 7.16.5
+
+  /@babel/plugin-syntax-jsx/7.16.7_@babel+core@7.17.4:
+    resolution: {integrity: sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.4
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
@@ -1690,24 +1874,34 @@ packages:
     dependencies:
       '@babel/plugin-transform-react-jsx': 7.16.5
 
-  /@babel/plugin-transform-react-jsx-self/7.16.5_@babel+core@7.16.5:
-    resolution: {integrity: sha512-fvwq+jir1Vn4f5oBS0H/J/gD5CneTD53MHs+NMjlHcha4Sq35fwxI5RtmJGEBXO+M93f/eeD9cAhRPhmLyJiVw==}
+  /@babel/plugin-transform-react-jsx-development/7.16.7_@babel+core@7.17.4:
+    resolution: {integrity: sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.16.5
-      '@babel/helper-plugin-utils': 7.16.5
+      '@babel/core': 7.17.4
+      '@babel/plugin-transform-react-jsx': 7.17.3_@babel+core@7.17.4
     dev: true
 
-  /@babel/plugin-transform-react-jsx-source/7.16.5_@babel+core@7.16.5:
-    resolution: {integrity: sha512-/eP+nZywJntGLjSPjksAnM9/ELIs3RbiEuTu2/zAOzwwBcfiu+m/iptEq1lERUUtSXubYSHVnVHMr13GR+TwPw==}
+  /@babel/plugin-transform-react-jsx-self/7.16.7_@babel+core@7.17.4:
+    resolution: {integrity: sha512-oe5VuWs7J9ilH3BCCApGoYjHoSO48vkjX2CbA5bFVhIuO2HKxA3vyF7rleA4o6/4rTDbk6r8hBW7Ul8E+UZrpA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.16.5
-      '@babel/helper-plugin-utils': 7.16.5
+      '@babel/core': 7.17.4
+      '@babel/helper-plugin-utils': 7.16.7
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-source/7.16.7_@babel+core@7.17.4:
+    resolution: {integrity: sha512-rONFiQz9vgbsnaMtQlZCjIRwhJvlrPET8TabIUK2hzlXw9B9s2Ieaxte1SCOOXMbWRHodbKixNf3BLcWVOQ8Bw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
   /@babel/plugin-transform-react-jsx/7.16.5:
@@ -1721,6 +1915,20 @@ packages:
       '@babel/helper-plugin-utils': 7.16.5
       '@babel/plugin-syntax-jsx': 7.16.5
       '@babel/types': 7.16.0
+
+  /@babel/plugin-transform-react-jsx/7.17.3_@babel+core@7.17.4:
+    resolution: {integrity: sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.4
+      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-module-imports': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/plugin-syntax-jsx': 7.16.7_@babel+core@7.17.4
+      '@babel/types': 7.17.0
+    dev: true
 
   /@babel/plugin-transform-react-pure-annotations/7.16.5:
     resolution: {integrity: sha512-0nYU30hCxnCVCbRjSy9ahlhWZ2Sn6khbY4FqR91W+2RbSqkWEbVu2gXh45EqNy4Bq7sRU+H4i0/6YKwOSzh16A==}
@@ -1961,6 +2169,15 @@ packages:
       '@babel/parser': 7.16.6
       '@babel/types': 7.16.0
 
+  /@babel/template/7.16.7:
+    resolution: {integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@babel/parser': 7.17.3
+      '@babel/types': 7.17.0
+    dev: true
+
   /@babel/traverse/7.16.5:
     resolution: {integrity: sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==}
     engines: {node: '>=6.9.0'}
@@ -1978,12 +2195,38 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/traverse/7.17.3:
+    resolution: {integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@babel/generator': 7.17.3
+      '@babel/helper-environment-visitor': 7.16.7
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-hoist-variables': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+      '@babel/parser': 7.17.3
+      '@babel/types': 7.17.0
+      debug: 4.3.3
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types/7.16.0:
     resolution: {integrity: sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.15.7
       to-fast-properties: 2.0.0
+
+  /@babel/types/7.17.0:
+    resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.16.7
+      to-fast-properties: 2.0.0
+    dev: true
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2204,6 +2447,22 @@ packages:
       '@types/node': 14.18.3
       '@types/yargs': 15.0.14
       chalk: 4.1.2
+    dev: true
+
+  /@jridgewell/resolve-uri/3.0.5:
+    resolution: {integrity: sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.11:
+    resolution: {integrity: sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==}
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.4:
+    resolution: {integrity: sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.0.5
+      '@jridgewell/sourcemap-codec': 1.4.11
     dev: true
 
   /@mdx-js/mdx/1.6.22:
@@ -2692,15 +2951,18 @@ packages:
     dev: true
     optional: true
 
-  /@vitejs/plugin-react-refresh/1.3.6:
-    resolution: {integrity: sha512-iNR/UqhUOmFFxiezt0em9CgmiJBdWR+5jGxB2FihaoJfqGt76kiwaKoVOJVU5NYcDWMdN06LbyN2VIGIoYdsEA==}
+  /@vitejs/plugin-react/1.2.0:
+    resolution: {integrity: sha512-Rywwt0IXXg6yQ0hv3cMT3mtdDcGIw31mGaa+MMMAT651LhoXLF2yFy4LrakiTs7UKs7RPBo9eNgaS8pgl2A6Qw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@babel/core': 7.16.5
-      '@babel/plugin-transform-react-jsx-self': 7.16.5_@babel+core@7.16.5
-      '@babel/plugin-transform-react-jsx-source': 7.16.5_@babel+core@7.16.5
+      '@babel/core': 7.17.4
+      '@babel/plugin-transform-react-jsx': 7.17.3_@babel+core@7.17.4
+      '@babel/plugin-transform-react-jsx-development': 7.16.7_@babel+core@7.17.4
+      '@babel/plugin-transform-react-jsx-self': 7.16.7_@babel+core@7.17.4
+      '@babel/plugin-transform-react-jsx-source': 7.16.7_@babel+core@7.17.4
       '@rollup/pluginutils': 4.1.2
-      react-refresh: 0.10.0
+      react-refresh: 0.11.0
+      resolve: 1.22.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5090,6 +5352,12 @@ packages:
     resolution: {integrity: sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==}
     dependencies:
       has: 1.0.3
+
+  /is-core-module/2.8.1:
+    resolution: {integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==}
+    dependencies:
+      has: 1.0.3
+    dev: true
 
   /is-data-descriptor/0.1.4:
     resolution: {integrity: sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=}
@@ -7566,8 +7834,8 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: true
 
-  /react-refresh/0.10.0:
-    resolution: {integrity: sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==}
+  /react-refresh/0.11.0:
+    resolution: {integrity: sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -7843,6 +8111,15 @@ packages:
     dependencies:
       is-core-module: 2.8.0
       path-parse: 1.0.7
+
+  /resolve/1.22.0:
+    resolution: {integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.8.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
 
   /ret/0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
@@ -8403,6 +8680,11 @@ packages:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
+    dev: true
+
+  /supports-preserve-symlinks-flag/1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /svgo/2.8.0:


### PR DESCRIPTION
At present, we can't use the typescript tsconfig.json's `compilerOptions.jsx` option to 'react-jsx'.