### PR TITLE
chore: replace `rm -rf` with `rimraf`

### DIFF
--- a/doc-site/package.json
+++ b/doc-site/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev": "vite serve",
     "debug": "node --inspect ./node_modules/vite/bin/vite serve",
-    "build": "rm -rf dist && vite build --outDir dist && serve -s dist",
-    "ssr": "rm -rf dist && vite-pages ssr && serve dist",
-    "ssr-for-deploy": "rm -rf dist && GITHUB_PAGES_DEPLOY=true vite-pages ssr",
+    "build": "rimraf dist && vite build --outDir dist && serve -s dist",
+    "ssr": "rimraf dist && vite-pages ssr && serve dist",
+    "ssr-for-deploy": "rimraf dist && GITHUB_PAGES_DEPLOY=true vite-pages ssr",
     "deploy": "npm run ssr-for-deploy && touch ./dist/.nojekyll && gh-pages -d dist -t"
   },
   "keywords": [],
@@ -24,6 +24,7 @@
     "@types/react-router-dom": "^5.1.7",
     "@vitejs/plugin-react": "^1.1.4",
     "gh-pages": "^3.1.0",
+    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "vite": "^2.9.12",
     "vite-pages-theme-doc": "workspace:*",

--- a/packages/create-project/template-app/package.json
+++ b/packages/create-project/template-app/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "vite serve",
-    "build": "rm -rf dist && vite build --outDir dist && serve -s dist",
-    "ssr": "rm -rf dist && vite-pages ssr && serve dist"
+    "build": "rimraf dist && vite build --outDir dist && serve -s dist",
+    "ssr": "rimraf dist && vite-pages ssr && serve dist"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +22,7 @@
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
     "@vitejs/plugin-react": "^1.1.4",
+    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "vite": "^2.9.12",
     "vite-pages-theme-doc": "^3.1.4",

--- a/packages/create-project/template-lib-monorepo/packages/button/package.json
+++ b/packages/create-project/template-lib-monorepo/packages/button/package.json
@@ -3,13 +3,14 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "rm -rf ./lib && tsc -p src && node ../../script/copy.js"
+    "build": "rimraf ./lib && tsc -p src && node ../../script/copy.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "@types/react": "^17.0.3",
+    "rimraf": "^3.0.2",
     "react": "^17.0.1",
     "typescript": "^4.7.3"
   }

--- a/packages/create-project/template-lib-monorepo/packages/card/package.json
+++ b/packages/create-project/template-lib-monorepo/packages/card/package.json
@@ -3,13 +3,14 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "rm -rf ./lib && tsc -p src && node ../../script/copy.js"
+    "build": "rimraf ./lib && tsc -p src && node ../../script/copy.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "@types/react": "^17.0.3",
+    "rimraf": "^3.0.2",
     "react": "^17.0.1",
     "typescript": "^4.7.3"
   }

--- a/packages/create-project/template-lib-monorepo/packages/demos/package.json
+++ b/packages/create-project/template-lib-monorepo/packages/demos/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "SHOW_ALL_COMPONENT_DEMOS=true vite serve",
-    "build": "rm -rf dist && vite build && serve -s dist",
-    "ssr": "rm -rf dist && vite-pages ssr && serve dist"
+    "build": "rimraf dist && vite build && serve -s dist",
+    "ssr": "rimraf dist && vite-pages ssr && serve dist"
   },
   "keywords": [],
   "author": "",
@@ -25,6 +25,7 @@
     "globby": "^11.0.2",
     "my-button": "*",
     "my-card": "*",
+    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "vite": "^2.9.12",
     "vite-pages-theme-doc": "^3.0.0",

--- a/packages/create-project/template-lib/package.json
+++ b/packages/create-project/template-lib/package.json
@@ -5,8 +5,8 @@
   "version": "0.0.3",
   "scripts": {
     "dev": "SHOW_ALL_COMPONENT_DEMOS=true vite serve docs",
-    "build": "rm -rf docs/dist && vite build docs && serve -s docs/dist",
-    "ssr": "rm -rf docs/dist && vite-pages ssr docs && serve docs/dist"
+    "build": "rimraf docs/dist && vite build docs && serve -s docs/dist",
+    "ssr": "rimraf docs/dist && vite-pages ssr docs && serve docs/dist"
   },
   "dependencies": {
     "react": "^17.0.1",
@@ -20,6 +20,7 @@
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
     "@vitejs/plugin-react": "^1.1.4",
+    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "vite": "^2.9.12",
     "vite-pages-theme-doc": "^3.1.4",

--- a/packages/playground/basic/package.json
+++ b/packages/playground/basic/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "dev": "vite serve",
     "debug": "node --inspect ./node_modules/vite/bin/vite serve",
-    "build": "rm -rf dist && vite build --outDir dist && serve -s dist",
+    "build": "rimraf dist && vite build --outDir dist && serve -s dist",
     "debug:build": "node --inspect ./node_modules/vite/bin/vite build --outDir dist",
-    "ssr": "rm -rf dist && vite-pages ssr",
-    "debug:ssr": "rm -rf dist && node --inspect-brk ./node_modules/vite-plugin-react-pages/bin/vite-pages.js ssr"
+    "ssr": "rimraf dist && vite-pages ssr",
+    "debug:ssr": "rimraf dist && node --inspect-brk ./node_modules/vite-plugin-react-pages/bin/vite-pages.js ssr"
   },
   "dependencies": {
     "react": "^17.0.1",
@@ -21,6 +21,7 @@
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
     "@vitejs/plugin-react": "^1.1.4",
+    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "vite": "^2.9.12",
     "vite-plugin-mdx": "^3.5.6",

--- a/packages/playground/custom-find-pages/package.json
+++ b/packages/playground/custom-find-pages/package.json
@@ -3,13 +3,13 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "clean": "rm -rf node_modules/.vite_opt_cache",
+    "clean": "rimraf node_modules/.vite_opt_cache",
     "dev": "vite serve",
     "debug": "node --inspect ./node_modules/vite/bin/vite serve",
-    "build": "rm -rf dist && vite build --outDir dist && serve -s dist",
+    "build": "rimraf dist && vite build --outDir dist && serve -s dist",
     "debug:build": "node --inspect node_modules/vite/bin/vite.js build --outDir dist",
-    "ssr": "rm -rf dist && vite-pages ssr && serve dist",
-    "debug:ssr": "rm -rf dist && node --inspect node_modules/vite-plugin-react-pages/bin/vite-pages.js ssr"
+    "ssr": "rimraf dist && vite-pages ssr && serve dist",
+    "debug:ssr": "rimraf dist && node --inspect node_modules/vite-plugin-react-pages/bin/vite-pages.js ssr"
   },
   "keywords": [],
   "author": "",
@@ -23,6 +23,7 @@
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
     "@vitejs/plugin-react": "^1.1.4",
+    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "vite": "^2.9.12",
     "vite-pages-theme-basic": "workspace:*",

--- a/packages/playground/custom-find-pages2/package.json
+++ b/packages/playground/custom-find-pages2/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "clean": "rm -rf ./pages/dist",
+    "clean": "rimraf ./pages/dist",
     "dev": "vite pages",
     "debug": "node --inspect ./node_modules/vite/bin/vite serve pages",
     "build": "npm run clean && vite build pages --outDir dist && serve -s pages/dist",
@@ -23,6 +23,7 @@
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
     "@vitejs/plugin-react": "^1.1.4",
+    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "vite": "^2.9.12",
     "vite-pages-theme-basic": "workspace:*",

--- a/packages/playground/lib-monorepo/packages/button/package.json
+++ b/packages/playground/lib-monorepo/packages/button/package.json
@@ -3,13 +3,14 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "rm -rf ./lib && tsc -p src && node ../../script/copy.js"
+    "build": "rimraf ./lib && tsc -p src && node ../../script/copy.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "@types/react": "^17.0.3",
+    "rimraf": "^3.0.2",
     "react": "^17.0.1",
     "typescript": "^4.7.3"
   }

--- a/packages/playground/lib-monorepo/packages/card/package.json
+++ b/packages/playground/lib-monorepo/packages/card/package.json
@@ -3,13 +3,14 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "rm -rf ./lib && tsc -p src && node ../../script/copy.js"
+    "build": "rimraf ./lib && tsc -p src && node ../../script/copy.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "@types/react": "^17.0.3",
+    "rimraf": "^3.0.2",
     "react": "^17.0.1",
     "typescript": "^4.7.3"
   }

--- a/packages/playground/lib-monorepo/packages/demos/package.json
+++ b/packages/playground/lib-monorepo/packages/demos/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "vite serve --config ./vite.demos.ts",
-    "build": "rm -rf dist && vite build --config ./vite.demos.ts --outDir dist && serve -s dist",
-    "ssr": "rm -rf dist && vite-pages ssr --configFile ./vite.demos.ts && serve dist"
+    "build": "rimraf dist && vite build --config ./vite.demos.ts --outDir dist && serve -s dist",
+    "ssr": "rimraf dist && vite-pages ssr --configFile ./vite.demos.ts && serve dist"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +22,7 @@
     "globby": "^11.0.2",
     "playground-button": "*",
     "playground-card": "*",
+    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "vite": "^2.9.12",
     "vite-pages-theme-basic": "workspace:*",

--- a/packages/playground/use-theme-doc/package.json
+++ b/packages/playground/use-theme-doc/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "dev": "vite serve",
     "debug": "node --inspect ./node_modules/vite/bin/vite serve",
-    "build": "rm -rf dist && vite build --outDir dist && serve -s dist",
+    "build": "rimraf dist && vite build --outDir dist && serve -s dist",
     "debug:build": "node --inspect ./node_modules/vite/bin/vite build --outDir dist",
-    "ssr": "rm -rf dist && vite-pages ssr && serve dist",
-    "debug:ssr": "rm -rf dist && node --inspect-brk ./node_modules/vite-plugin-react-pages/bin/vite-pages.js ssr"
+    "ssr": "rimraf dist && vite-pages ssr && serve dist",
+    "debug:ssr": "rimraf dist && node --inspect-brk ./node_modules/vite-plugin-react-pages/bin/vite-pages.js ssr"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +22,7 @@
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
     "@vitejs/plugin-react": "^1.1.4",
+    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "vite": "^2.9.12",
     "vite-pages-theme-doc": "workspace:*",

--- a/packages/playground/use-theme/package.json
+++ b/packages/playground/use-theme/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "dev": "vite serve",
     "debug": "node --inspect ./node_modules/vite/bin/vite serve",
-    "build": "rm -rf dist && vite build --outDir dist && serve -s dist",
+    "build": "rimraf dist && vite build --outDir dist && serve -s dist",
     "debug:build": "node --inspect ./node_modules/vite/bin/vite build --outDir dist",
-    "ssr": "rm -rf dist && vite-pages ssr && serve dist",
-    "debug:ssr": "rm -rf dist && node --inspect-brk ./node_modules/vite-plugin-react-pages/bin/vite-pages.js ssr"
+    "ssr": "rimraf dist && vite-pages ssr && serve dist",
+    "debug:ssr": "rimraf dist && node --inspect-brk ./node_modules/vite-plugin-react-pages/bin/vite-pages.js ssr"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +22,7 @@
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
     "@vitejs/plugin-react": "^1.1.4",
+    "rimraf": "^3.0.2",
     "serve": "^13.0.2",
     "vite": "^2.9.12",
     "vite-pages-theme-basic": "workspace:*",

--- a/packages/react-pages/package.json
+++ b/packages/react-pages/package.json
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/vitejs/vite-plugin-react-pages",
   "scripts": {
-    "build": "rm -rf ./dist && concurrently \"npm:build-*\"",
+    "build": "rimraf ./dist && concurrently \"npm:build-*\"",
     "build-node": "tsc -p src/node",
     "build-client": "tsc -p src/client",
-    "dev": "rm -rf ./dist && concurrently \"npm:dev-*\"",
+    "dev": "rimraf ./dist && concurrently \"npm:dev-*\"",
     "dev-node": "tsc -w -p src/node",
     "dev-client": "tsc -w -p src/client",
     "prepare": "npm run build"
@@ -42,6 +42,7 @@
     "@types/react-router-dom": "^5.1.7",
     "concurrently": "^7.2.1",
     "react": "^17.0.1",
+    "rimraf": "^3.0.2",
     "rollup": "^2.75.6",
     "typescript": "^4.3.2",
     "vite": "^2.9.12",

--- a/packages/theme-basic/package.json
+++ b/packages/theme-basic/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/vitejs/vite-plugin-react-pages",
   "scripts": {
-    "build": "rm -rf ./dist ./lib && tsc && rollup -c && node scripts/add-css-import.js && node ./scripts/fix-css-charset.js",
-    "dev": "rm -rf ./dist && concurrently \"npm:dev-*\"",
+    "build": "rimraf ./dist ./lib && tsc && rollup -c && node scripts/add-css-import.js && node ./scripts/fix-css-charset.js",
+    "dev": "rimraf ./dist && concurrently \"npm:dev-*\"",
     "dev-rollup": "rollup -wc",
     "dev-watch": "node scripts/watch",
     "prepare": "npm run build",
@@ -50,6 +50,7 @@
     "fs-extra": "^9.1.0",
     "globby": "^11.0.2",
     "prism-react-renderer": "^1.2.0",
+    "rimraf": "^3.0.2",
     "react": "^17.0.1",
     "rollup": "^2.75.6",
     "rollup-plugin-postcss": "^4.0.0",

--- a/packages/theme-doc/package.json
+++ b/packages/theme-doc/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/vitejs/vite-plugin-react-pages",
   "scripts": {
-    "clean": "rm -rf ./dist ./lib ./dist-cjs",
+    "clean": "rimraf ./dist ./lib ./dist-cjs",
     "build": "npm run clean && concurrently \"npm:build-*\"",
     "build-dts": "tsc",
     "build-copy-files": "node ./scripts/copy.js",
@@ -53,6 +53,7 @@
     "less": "^4.1.3",
     "postcss": "^8.4.14",
     "prism-react-renderer": "^1.2.0",
+    "rimraf": "^3.0.2",
     "rollup": "^2.75.6",
     "rollup-plugin-postcss": "^4.0.0",
     "tslib": "^2.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
+      rimraf: ^3.0.2
       serve: ^13.0.2
       vite: ^2.9.12
       vite-pages-theme-doc: workspace:*
@@ -59,6 +60,7 @@ importers:
       '@types/react-router-dom': 5.3.3
       '@vitejs/plugin-react': 1.3.2
       gh-pages: 3.2.3
+      rimraf: 3.0.2
       serve: 13.0.2
       vite: 2.9.12
       vite-pages-theme-doc: link:../packages/theme-doc
@@ -84,6 +86,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
+      rimraf: ^3.0.2
       serve: ^13.0.2
       vite: ^2.9.12
       vite-pages-theme-doc: ^3.1.4
@@ -100,6 +103,7 @@ importers:
       '@types/react': 17.0.45
       '@types/react-router-dom': 5.3.3
       '@vitejs/plugin-react': 1.3.2
+      rimraf: 3.0.2
       serve: 13.0.2
       vite: 2.9.12
       vite-pages-theme-doc: link:../../theme-doc
@@ -117,6 +121,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
+      rimraf: ^3.0.2
       serve: ^13.0.2
       vite: ^2.9.12
       vite-pages-theme-doc: ^3.1.4
@@ -133,6 +138,7 @@ importers:
       '@types/react': 17.0.45
       '@types/react-router-dom': 5.3.3
       '@vitejs/plugin-react': 1.3.2
+      rimraf: 3.0.2
       serve: 13.0.2
       vite: 2.9.12
       vite-pages-theme-doc: link:../../theme-doc
@@ -146,20 +152,24 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       react: ^17.0.1
+      rimraf: ^3.0.2
       typescript: ^4.7.3
     devDependencies:
       '@types/react': 17.0.45
       react: 17.0.2
+      rimraf: 3.0.2
       typescript: 4.7.3
 
   packages/create-project/template-lib-monorepo/packages/card:
     specifiers:
       '@types/react': ^17.0.3
       react: ^17.0.1
+      rimraf: ^3.0.2
       typescript: ^4.7.3
     devDependencies:
       '@types/react': 17.0.45
       react: 17.0.2
+      rimraf: 3.0.2
       typescript: 4.7.3
 
   packages/create-project/template-lib-monorepo/packages/demos:
@@ -176,6 +186,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
+      rimraf: ^3.0.2
       serve: ^13.0.2
       vite: ^2.9.12
       vite-pages-theme-doc: ^3.0.0
@@ -195,6 +206,7 @@ importers:
       globby: 11.1.0
       my-button: link:../button
       my-card: link:../card
+      rimraf: 3.0.2
       serve: 13.0.2
       vite: 2.9.12
       vite-pages-theme-doc: link:../../../../theme-doc
@@ -216,6 +228,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
+      rimraf: ^3.0.2
       serve: ^13.0.2
       vite: ^2.9.12
       vite-plugin-mdx: ^3.5.6
@@ -229,6 +242,7 @@ importers:
       '@types/react': 17.0.45
       '@types/react-router-dom': 5.3.3
       '@vitejs/plugin-react': 1.3.2
+      rimraf: 3.0.2
       serve: 13.0.2
       vite: 2.9.12
       vite-plugin-mdx: 3.5.10_ywwgxu3gd3ozxshfwjcjlap47u
@@ -242,6 +256,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
+      rimraf: ^3.0.2
       serve: ^13.0.2
       vite: ^2.9.12
       vite-pages-theme-basic: workspace:*
@@ -255,6 +270,7 @@ importers:
       '@types/react': 17.0.45
       '@types/react-router-dom': 5.3.3
       '@vitejs/plugin-react': 1.3.2
+      rimraf: 3.0.2
       serve: 13.0.2
       vite: 2.9.12
       vite-pages-theme-basic: link:../../theme-basic
@@ -269,6 +285,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
+      rimraf: ^3.0.2
       serve: ^13.0.2
       vite: ^2.9.12
       vite-pages-theme-basic: workspace:*
@@ -282,6 +299,7 @@ importers:
       '@types/react': 17.0.45
       '@types/react-router-dom': 5.3.3
       '@vitejs/plugin-react': 1.3.2
+      rimraf: 3.0.2
       serve: 13.0.2
       vite: 2.9.12
       vite-pages-theme-basic: link:../../theme-basic
@@ -295,20 +313,24 @@ importers:
     specifiers:
       '@types/react': ^17.0.3
       react: ^17.0.1
+      rimraf: ^3.0.2
       typescript: ^4.7.3
     devDependencies:
       '@types/react': 17.0.45
       react: 17.0.2
+      rimraf: 3.0.2
       typescript: 4.7.3
 
   packages/playground/lib-monorepo/packages/card:
     specifiers:
       '@types/react': ^17.0.3
       react: ^17.0.1
+      rimraf: ^3.0.2
       typescript: ^4.7.3
     devDependencies:
       '@types/react': 17.0.45
       react: 17.0.2
+      rimraf: 3.0.2
       typescript: 4.7.3
 
   packages/playground/lib-monorepo/packages/demos:
@@ -322,6 +344,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
+      rimraf: ^3.0.2
       serve: ^13.0.2
       vite: ^2.9.12
       vite-pages-theme-basic: workspace:*
@@ -338,6 +361,7 @@ importers:
       globby: 11.1.0
       playground-button: link:../button
       playground-card: link:../card
+      rimraf: 3.0.2
       serve: 13.0.2
       vite: 2.9.12
       vite-pages-theme-basic: link:../../../../theme-basic
@@ -352,6 +376,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
+      rimraf: ^3.0.2
       serve: ^13.0.2
       vite: ^2.9.12
       vite-pages-theme-basic: workspace:*
@@ -365,6 +390,7 @@ importers:
       '@types/react': 17.0.45
       '@types/react-router-dom': 5.3.3
       '@vitejs/plugin-react': 1.3.2
+      rimraf: 3.0.2
       serve: 13.0.2
       vite: 2.9.12
       vite-pages-theme-basic: link:../../theme-basic
@@ -379,6 +405,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       react-router-dom: ^5.2.0
+      rimraf: ^3.0.2
       serve: ^13.0.2
       vite: ^2.9.12
       vite-pages-theme-doc: workspace:*
@@ -392,6 +419,7 @@ importers:
       '@types/react': 17.0.45
       '@types/react-router-dom': 5.3.3
       '@vitejs/plugin-react': 1.3.2
+      rimraf: 3.0.2
       serve: 13.0.2
       vite: 2.9.12
       vite-pages-theme-doc: link:../../theme-doc
@@ -420,6 +448,7 @@ importers:
       minimist: ^1.2.5
       react: ^17.0.1
       remark-frontmatter: ^2.0.0
+      rimraf: ^3.0.2
       rollup: ^2.75.6
       slash: ^3.0.0
       tiny-invariant: ^1.1.0
@@ -453,6 +482,7 @@ importers:
       '@types/react-router-dom': 5.3.3
       concurrently: 7.2.1
       react: 17.0.2
+      rimraf: 3.0.2
       rollup: 2.75.6
       vite: 2.9.12
       vite-plugin-mdx: 3.5.10_vite@2.9.12
@@ -482,6 +512,7 @@ importers:
       postcss: ^8.4.14
       prism-react-renderer: ^1.2.0
       react: ^17.0.1
+      rimraf: ^3.0.2
       rollup: ^2.75.6
       rollup-plugin-postcss: ^4.0.0
       sass: ^1.52.3
@@ -512,6 +543,7 @@ importers:
       postcss: 8.4.14
       prism-react-renderer: 1.3.3_react@17.0.2
       react: 17.0.2
+      rimraf: 3.0.2
       rollup: 2.75.6
       rollup-plugin-postcss: 4.0.2_postcss@8.4.14
       sass: 1.52.3
@@ -540,6 +572,7 @@ importers:
       less: ^4.1.3
       postcss: ^8.4.14
       prism-react-renderer: ^1.2.0
+      rimraf: ^3.0.2
       rollup: ^2.75.6
       rollup-plugin-postcss: ^4.0.0
       tslib: ^2.4.0
@@ -566,6 +599,7 @@ importers:
       less: 4.1.3
       postcss: 8.4.14
       prism-react-renderer: 1.3.3
+      rimraf: 3.0.2
       rollup: 2.75.6
       rollup-plugin-postcss: 4.0.2_postcss@8.4.14
       tslib: 2.4.0
@@ -5391,7 +5425,7 @@ packages:
     dev: true
 
   /inflight/1.0.6:
-    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
@@ -6842,7 +6876,7 @@ packages:
     dev: true
 
   /once/1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: true
@@ -6964,7 +6998,7 @@ packages:
     dev: true
 
   /path-is-absolute/1.0.1:
-    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -9657,7 +9691,7 @@ packages:
     dev: true
 
   /wrappy/1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: true
 
   /write-file-atomic/3.0.3:


### PR DESCRIPTION
Use `rimraf` instead of  `rm -rf` for better experience on Windows environment.