### PR TITLE
feat: add support for `mjs` and `mts` extensions

### DIFF
--- a/doc-site/pages/advanced-fs-routing$.mdx
+++ b/doc-site/pages/advanced-fs-routing$.mdx
@@ -19,7 +19,7 @@ vite.config.ts:
   syntax="ts"
 />
 
-With this custom pageStrategy, page files don't need to ends with `$`. Instead, they need to match the pattern `**/index.{md,mdx,js,jsx,ts,tsx}`.
+With this custom pageStrategy, page files don't need to ends with `$`. Instead, they need to match the pattern `**/index.{md,mdx,js,jsx,mjs,mts,ts,tsx}`.
 
 > Checkout complete examples in [the custom-find-pages2 fixture](https://github.com/vitejs/vite-plugin-react-pages/blob/main/packages/playground/custom-find-pages2/vite.config.ts) or [the project scaffold](https://github.com/vitejs/vite-plugin-react-pages/blob/main/packages/create-project/template-lib/docs/vite.config.ts).
 
@@ -134,7 +134,7 @@ export class DefaultPageStrategy extends PageStrategy {
       // we can create our own helpers, providing a default fileHandler
       // and not using helpersFromParent
       const helpers = this.createHelpers(fileHandler)
-      helpers.watchFiles(pagesDir, '**/*$.{md,mdx,js,jsx,ts,tsx}')
+      helpers.watchFiles(pagesDir, '**/*$.{md,mdx,js,jsx,mjs,mts,ts,tsx}')
       if (typeof extraFindPages === 'function') {
         extraFindPages(pagesDir, helpers)
       }

--- a/doc-site/pages/fs-routing$.mdx
+++ b/doc-site/pages/fs-routing$.mdx
@@ -15,7 +15,7 @@ The basic filesystem routing convention is very intuitive. It works out of the b
 
 If the filename is `index$.tsx`, the page route path will be the path of the directory. See examples below.
 
-> All file extensions `.ts|.tsx|.js|.jsx|.md|.mdx` works, as long as `$` is the last character before the extension.
+> All file extensions `.ts|.tsx|.js|.jsx|.mjs|.mts|.md|.mdx` works, as long as `$` is the last character before the extension.
 
 ## Examples
 

--- a/doc-site/pages/magic-import$_deprecate.mdx
+++ b/doc-site/pages/magic-import$_deprecate.mdx
@@ -50,7 +50,7 @@ Checkout the [analyze-source-code fixture](https://github.com/vitejs/vite-plugin
 
 For relative module dependencies(.e.g `import util from './dir/util.ts'`), their source code will be collected into the analyze result, as shown by the previous example.
 
-Relative module import can be js, jsx, ts, tsx, css, sass, etc.
+Relative module import can be js, jsx, mjs, mts, ts, tsx, css, sass, etc.
 
 ### External module dependencies
 

--- a/packages/playground/custom-find-pages2/pages/vite.config.ts
+++ b/packages/playground/custom-find-pages2/pages/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       pageStrategy: new PageStrategy(function findPages(pagesDir, helpers) {
         helpers.watchFiles(
           pagesDir,
-          '**/index.{md,mdx,js,jsx,ts,tsx}',
+          '**/index.{md,mdx,js,jsx,mjs,mts,ts,tsx}',
           fileHandler
         )
       }),
@@ -42,7 +42,7 @@ const fileHandler: FileHandler = async (file: File, fileHandlerAPI) => {
 function getPagePublicPath(relativePageFilePath: string) {
   console.log('getPagePublicPath', relativePageFilePath)
   let pagePublicPath = relativePageFilePath.replace(
-    /index\.(md|mdx|js|jsx|ts|tsx)$/,
+    /index\.(md|mdx|mjs|mts|js|jsx|ts|tsx)$/,
     ''
   )
   // remove ending slash

--- a/packages/react-pages/src/node/page-strategy/DefaultPageStrategy/index.ts
+++ b/packages/react-pages/src/node/page-strategy/DefaultPageStrategy/index.ts
@@ -12,7 +12,7 @@ export class DefaultPageStrategy extends PageStrategy {
       // we can create our own helpers, providing a default fileHandler
       // and not using helpersFromParent
       const helpers = this.createHelpers(fileHandler)
-      helpers.watchFiles(pagesDir, '**/*$.{md,mdx,js,jsx,ts,tsx}')
+      helpers.watchFiles(pagesDir, '**/*$.{md,mdx,js,jsx,mjs,mts,ts,tsx}')
       if (typeof extraFindPages === 'function') {
         extraFindPages(pagesDir, helpers)
       }
@@ -39,7 +39,7 @@ export const defaultFileHandler: FileHandler = async (file: File, api) => {
  */
 export function getPagePublicPath(relativePageFilePath: string) {
   let pagePublicPath = relativePageFilePath.replace(
-    /\$\.(md|mdx|js|jsx|ts|tsx)$/,
+    /\$\.(md|mdx|mjs|mts|js|jsx|ts|tsx)$/,
     ''
   )
   pagePublicPath = pagePublicPath.replace(/index$/, '')

--- a/packages/react-pages/src/node/utils/virtual-module/utils/extractStaticData.ts
+++ b/packages/react-pages/src/node/utils/virtual-module/utils/extractStaticData.ts
@@ -17,6 +17,8 @@ export async function extractStaticData(
       return staticData
     case 'js':
     case 'jsx':
+    case 'mjs':
+    case 'mts':
     case 'ts':
     case 'tsx':
       return { ...parse(extract(code)), sourceType: 'js' }

--- a/packages/theme-basic/rollup.config.js
+++ b/packages/theme-basic/rollup.config.js
@@ -4,7 +4,7 @@ import babel from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import resolve from '@rollup/plugin-node-resolve'
 
-const extensions = ['.js', '.jsx', '.ts', '.tsx']
+const extensions = ['.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx']
 
 export default {
   input: 'src/index.tsx',

--- a/packages/theme-doc/rollup.config.js
+++ b/packages/theme-doc/rollup.config.js
@@ -3,7 +3,7 @@ import babel from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import resolve from '@rollup/plugin-node-resolve'
 
-const extensions = ['.js', '.jsx', '.ts', '.tsx']
+const extensions = ['.js', '.jsx', 'mjs', 'mts', '.ts', '.tsx']
 
 export default {
   input: 'src/index.tsx',


### PR DESCRIPTION
As of 4.7 , TypeScript supported some new file [extensions](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#new-file-extensions) such as `mts` and their emitted version -- `mjs`, maybe there's a need to add such features.