### PR TITLE
chore: remove fast-deep-equal

### DIFF
--- a/packages/react-pages/package.json
+++ b/packages/react-pages/package.json
@@ -53,7 +53,6 @@
     "chokidar": "^3.5.1",
     "dequal": "^2.0.2",
     "enhanced-resolve": "^5.7.0",
-    "fast-deep-equal": "^3.1.3",
     "fs-extra": "^9.1.0",
     "gray-matter": "^4.0.2",
     "jest-docblock": "^26.0.0",

--- a/packages/react-pages/src/node/page-strategy/PagesDataKeeper.ts
+++ b/packages/react-pages/src/node/page-strategy/PagesDataKeeper.ts
@@ -1,4 +1,4 @@
-import equal from 'fast-deep-equal'
+import { dequal } from 'dequal'
 
 import { PageUpdateBuffer } from './UpdateBuffer'
 import {
@@ -88,14 +88,14 @@ export class PagesDataKeeper extends PageUpdateBuffer {
     }
     // Page is updated
     this.pages[pageId] = pageData
-    if (!equal(pageData.runtimeData, oldPageData.runtimeData)) {
+    if (!dequal(pageData.runtimeData, oldPageData.runtimeData)) {
       this.scheduleUpdate({
         type: 'update',
         dataType: 'runtime',
         pageId,
       })
     }
-    if (!equal(pageData.staticData, oldPageData.staticData)) {
+    if (!dequal(pageData.staticData, oldPageData.staticData)) {
       this.scheduleUpdate({
         type: 'update',
         dataType: 'static',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,7 +439,6 @@ importers:
       concurrently: ^7.2.1
       dequal: ^2.0.2
       enhanced-resolve: ^5.7.0
-      fast-deep-equal: ^3.1.3
       fs-extra: ^9.1.0
       gray-matter: ^4.0.2
       jest-docblock: ^26.0.0
@@ -461,7 +460,6 @@ importers:
       chokidar: 3.5.3
       dequal: 2.0.2
       enhanced-resolve: 5.9.3
-      fast-deep-equal: 3.1.3
       fs-extra: 9.1.0
       gray-matter: 4.0.3
       jest-docblock: 26.0.0
@@ -4869,6 +4867,7 @@ packages:
 
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
 
   /fast-glob/3.2.11:
     resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}


### PR DESCRIPTION
`fast-deep-equal` plays the same role as `dequal` , remove one of them.