### PR TITLE
[WIP] feat(theme-doc): search

### DIFF
--- a/packages/theme-doc/src/Layout/Header.tsx
+++ b/packages/theme-doc/src/Layout/Header.tsx
@@ -13,6 +13,7 @@ import type { MenuConfig } from './renderMenu'
 import { LayoutContext } from './ctx'
 import { themeConfigCtx, useThemeCtx } from '../ctx'
 import { useLocaleSelector } from './useLocaleSelector'
+import Search from './Search'
 
 const renderMenu = renderMenuHelper(true)
 
@@ -114,6 +115,10 @@ const AppHeader: React.FC<Props> = (props) => {
         </span>
       </div>
       <div className={s.logoArea}>{renderLogo}</div>
+
+      <div className={s.searchArea}>
+        <Search />
+      </div>
 
       <div className={s.flexSpace}></div>
 

--- a/packages/theme-doc/src/Layout/Search/index.tsx
+++ b/packages/theme-doc/src/Layout/Search/index.tsx
@@ -2,44 +2,64 @@ import React, { useMemo, useState } from 'react'
 import type { PagesStaticData } from 'vite-plugin-react-pages'
 import { AutoComplete, Input } from 'antd'
 import { SearchOutlined } from '@ant-design/icons'
+import { useHistory } from 'react-router-dom'
 
 import { useThemeCtx } from '../..'
 
 import s from './search.module.less'
+import { matchPagePathLocalePrefix } from '../../analyzeStaticData'
 
 interface Props {}
 
 const Search: React.FC<Props> = (props) => {
-  const themeCtxValue = useThemeCtx()
+  const { staticData, themeConfig, resolvedLocale, pageGroups } = useThemeCtx()
   const [popupOpen, setPopupOpen] = useState(false)
   const [keywords, setKeywords] = useState('')
+  const history = useHistory()
 
-  console.log('@@themeCtxValue', themeCtxValue)
+  // const themeCtxValue = useThemeCtx()
+  // console.log('@@themeCtxValue', themeCtxValue)
+  // console.log('@@pageGroups', pageGroups)
+
+  const preparedStaticData: PagesStaticData = useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(staticData).filter(([pagePath, staticData]) => {
+        // pages with path params should not be showed in search result
+        if (pagePath.includes('/:')) return false
+        const { localeKey } = matchPagePathLocalePrefix(
+          pagePath,
+          themeConfig.i18n
+        )
+        // filter out pages with different locale
+        if (resolvedLocale.localeKey !== localeKey) return false
+        return true
+      })
+    )
+  }, [staticData, themeConfig.i18n, resolvedLocale.localeKey])
 
   const options = useMemo(() => {
-    const filteredData = filter(themeCtxValue.staticData, keywords)
+    const filteredData = filter(preparedStaticData, keywords)
     return filteredData.map(({ label, path }) => {
       return { value: path, label }
     })
-  }, [themeCtxValue.staticData, keywords])
+  }, [preparedStaticData, keywords])
 
   return (
     <div className={s['search-box']}>
       <AutoComplete
         popupClassName={s.popup}
         options={options}
-        // open
         open={popupOpen}
         placement="topLeft"
         onDropdownVisibleChange={setPopupOpen}
         value={keywords}
         onSearch={setKeywords}
         onSelect={(value: any, option: any) => {
-          console.log('@onSelect', value, option)
+          history.push(value)
         }}
       >
         <Input
-          placeholder="搜索"
+          placeholder="Search"
           prefix={<SearchOutlined className={s.icon} />}
           bordered={false}
           className={s.input}

--- a/packages/theme-doc/src/Layout/Search/index.tsx
+++ b/packages/theme-doc/src/Layout/Search/index.tsx
@@ -1,0 +1,77 @@
+import React, { useMemo, useState } from 'react'
+import type { PagesStaticData } from 'vite-plugin-react-pages'
+import { AutoComplete, Input } from 'antd'
+import { SearchOutlined } from '@ant-design/icons'
+
+import { useThemeCtx } from '../..'
+
+import s from './search.module.less'
+
+interface Props {}
+
+const Search: React.FC<Props> = (props) => {
+  const themeCtxValue = useThemeCtx()
+  const [popupOpen, setPopupOpen] = useState(false)
+  const [keywords, setKeywords] = useState('')
+
+  console.log('@@themeCtxValue', themeCtxValue)
+
+  const options = useMemo(() => {
+    const filteredData = filter(themeCtxValue.staticData, keywords)
+    return filteredData.map(({ label, path }) => {
+      return { value: path, label }
+    })
+  }, [themeCtxValue.staticData, keywords])
+
+  return (
+    <div className={s['search-box']}>
+      <AutoComplete
+        popupClassName={s.popup}
+        options={options}
+        // open
+        open={popupOpen}
+        placement="topLeft"
+        onDropdownVisibleChange={setPopupOpen}
+        value={keywords}
+        onSearch={setKeywords}
+        onSelect={(value: any, option: any) => {
+          console.log('@onSelect', value, option)
+        }}
+      >
+        <Input
+          placeholder="搜索"
+          prefix={<SearchOutlined className={s.icon} />}
+          bordered={false}
+          className={s.input}
+        />
+      </AutoComplete>
+    </div>
+  )
+}
+
+export default Search
+
+interface FilteredData {
+  readonly label: string
+  readonly path: string
+}
+
+function filter(
+  pagesStaticData: PagesStaticData,
+  keywords: string
+): FilteredData[] {
+  return Object.entries(pagesStaticData)
+    .map(([path, staticData]) => {
+      if (path === '/404') return null
+      const label = staticData.title ?? staticData.main.title ?? path
+      if (containString(label, keywords?.trim() ?? '')) {
+        return { label, path }
+      }
+      return null
+    })
+    .filter(Boolean) as FilteredData[]
+}
+
+function containString(whole: string, part: string) {
+  return whole.toLowerCase().indexOf(part.toLowerCase()) !== -1
+}

--- a/packages/theme-doc/src/Layout/Search/search.module.less
+++ b/packages/theme-doc/src/Layout/Search/search.module.less
@@ -1,0 +1,29 @@
+@search-icon-color: #ced4d9;
+
+.search-box {
+  > :global(.vp-antd-select) {
+    cursor: default;
+  }
+
+  border-left: 1px solid rgba(0, 0, 0, 0.06);
+  padding-left: 40px;
+  display: flex;
+  align-items: center;
+
+  .input {
+    padding: 4px 0px;
+    input::placeholder {
+      color: #a3b1bf;
+    }
+  }
+
+  .icon {
+    margin-right: 4px;
+    color: @search-icon-color;
+    pointer-events: none;
+  }
+}
+
+.popup {
+  width: 250px !important;
+}

--- a/packages/theme-doc/src/Layout/Sider.tsx
+++ b/packages/theme-doc/src/Layout/Sider.tsx
@@ -6,7 +6,7 @@ import { themePropsCtx } from '../ctx'
 import s from './index.module.less'
 import type { ThemeContextValue } from '..'
 import { LayoutContext } from './ctx'
-import { getOnePageGroupInfo } from '../analyzeStaticData'
+import { analyzePageInfo } from '../analyzeStaticData'
 import { getStaticDataValue } from '../utils'
 
 interface Props {
@@ -103,28 +103,28 @@ export function defaultSideNavs(
   opts?: DefaultSideNavsOpts
 ): MenuConfig[] | null {
   const { i18n } = themeConfig || {}
-  const currentGroupInfo = getOnePageGroupInfo(
+  const currentPageInfo = analyzePageInfo(
     loadState.routePath,
     staticData[loadState.routePath],
     i18n
   )
-  // console.log('defaultSideNavs', currentGroupInfo, groups)
+  // console.log('defaultSideNavs', currentPageInfo, groups)
 
   // groupKey of the current page
   const groupKey = (() => {
     if (opts?.forceGroup) return opts.forceGroup
     // infer the group of the current page.
-    // currentGroupInfo.group may be wrong because:
+    // currentPageInfo.group may be wrong because:
     // if there is also pages like /guide/start ,
     // then /guide should not be grouped with /faq .
     // instead, /guide should be moved to the "guide" group
     if (
-      currentGroupInfo.group === '/' &&
-      pageGroups[currentGroupInfo.pageKeyInGroup]
+      currentPageInfo.group === '/' &&
+      pageGroups[currentPageInfo.pageKeyInGroup]
     ) {
-      return currentGroupInfo.pageKeyInGroup
+      return currentPageInfo.pageKeyInGroup
     }
-    return currentGroupInfo.group
+    return currentPageInfo.group
   })()
 
   const subGroups = pageGroups[groupKey] ?? {}
@@ -135,7 +135,7 @@ export function defaultSideNavs(
     // remove pages with different locale
     .map(([subGroupKey, pages]) => {
       const filtered = pages.filter(
-        ({ pageLocaleKey }) => currentGroupInfo.localeKey === pageLocaleKey
+        ({ pageLocaleKey }) => currentPageInfo.localeKey === pageLocaleKey
       )
       return [subGroupKey, filtered] as const
     })

--- a/packages/theme-doc/src/Layout/Sider.tsx
+++ b/packages/theme-doc/src/Layout/Sider.tsx
@@ -4,9 +4,10 @@ import { Menu, Drawer } from 'antd'
 import { MenuConfig, renderMenuHelper } from './renderMenu'
 import { themePropsCtx } from '../ctx'
 import s from './index.module.less'
-import type { ThemeContextValue, I18nConfig, LocalConfig } from '..'
+import type { ThemeContextValue } from '..'
 import { LayoutContext } from './ctx'
-import { ensureStartSlash, removeStartSlash } from '../utils'
+import { getOnePageGroupInfo } from '../analyzeStaticData'
+import { getStaticDataValue } from '../utils'
 
 interface Props {
   sideNavsData: readonly MenuConfig[] | null | undefined
@@ -98,16 +99,15 @@ export interface DefaultSideNavsOpts {
 }
 
 export function defaultSideNavs(
-  { loadState, staticData, themeConfig }: ThemeContextValue,
+  { loadState, staticData, themeConfig, pageGroups }: ThemeContextValue,
   opts?: DefaultSideNavsOpts
 ): MenuConfig[] | null {
   const { i18n } = themeConfig || {}
-  const currentGroupInfo = getPageGroupInfo(
+  const currentGroupInfo = getOnePageGroupInfo(
     loadState.routePath,
     staticData[loadState.routePath],
     i18n
   )
-  const groups = getGroups(staticData, i18n)
   // console.log('defaultSideNavs', currentGroupInfo, groups)
 
   // groupKey of the current page
@@ -118,13 +118,16 @@ export function defaultSideNavs(
     // if there is also pages like /guide/start ,
     // then /guide should not be grouped with /faq .
     // instead, /guide should be moved to the "guide" group
-    if (currentGroupInfo.group === '/' && groups[currentGroupInfo.pageName]) {
-      return currentGroupInfo.pageName
+    if (
+      currentGroupInfo.group === '/' &&
+      pageGroups[currentGroupInfo.pageKeyInGroup]
+    ) {
+      return currentGroupInfo.pageKeyInGroup
     }
     return currentGroupInfo.group
   })()
 
-  const subGroups = groups[groupKey] ?? {}
+  const subGroups = pageGroups[groupKey] ?? {}
 
   const result: MenuConfig[] = []
 
@@ -162,16 +165,14 @@ export function defaultSideNavs(
           // pages with path params should not be showed in sideNav
           .filter((page) => !page.pagePath.includes('/:'))
           .forEach((page) => {
-            const label =
-              getStaticDataValue(page.pageStaticData, 'title') ?? page.pageName
             result.push({
-              label,
+              label: page.pageTitle,
               path: page.pagePath,
             })
           })
         return
       }
-      const groupLabel =
+      const subGroupLabel =
         getGroupConfig(groupKey, subGroupKey)?.label ?? subGroupKey
 
       const subGroupItems = pages
@@ -186,16 +187,14 @@ export function defaultSideNavs(
         // pages with path params should not be showed in sideNav
         .filter((page) => !page.pagePath.includes('/:'))
         .map((page) => {
-          const label =
-            getStaticDataValue(page.pageStaticData, 'title') ?? page.pageName
           return {
-            label,
+            label: page.pageTitle,
             path: page.pagePath,
           }
         })
       if (subGroupItems.length > 0)
         result.push({
-          group: groupLabel,
+          group: subGroupLabel,
           children: subGroupItems,
         })
     })
@@ -204,10 +203,6 @@ export function defaultSideNavs(
   function getGroupConfig(groupKey: string, subGroupKey: string) {
     return opts?.groupConfig?.[groupKey]?.[subGroupKey]
   }
-}
-
-function getStaticDataValue(pageStaticData: any, key: string) {
-  return pageStaticData?.[key] ?? pageStaticData?.main?.[key]
 }
 
 function sortPages(
@@ -221,140 +216,4 @@ function sortPages(
   if (!Number.isNaN(orderA) && !Number.isNaN(orderB) && orderA !== orderB)
     return orderA - orderB
   return pathA.localeCompare(pathB)
-}
-
-// map groups -> subgroups -> pages
-type Groups = {
-  [groupKey: string]: {
-    [subGroupKey: string]: PageMeta[]
-  }
-}
-
-type PageMeta = {
-  pagePath: string
-  pageStaticData: any
-  pageName: string
-  pageLocale: LocalConfig | undefined
-  pageLocaleKey: string | undefined
-}
-
-function getGroups(staticData: any, i18n: I18nConfig | undefined) {
-  const groups: Groups = {}
-  function ensureGroup(group: string): Record<string, PageMeta[]>
-  function ensureGroup(group: string, subGroup: string): PageMeta[]
-  function ensureGroup(group: string, subGroup?: string) {
-    const subGroups = (groups[group] ||= {})
-    if (!subGroup) return subGroups
-    return (subGroups[subGroup] ||= [])
-  }
-
-  Object.entries(staticData).forEach(([pagePath, pageStaticData]) => {
-    if (pagePath === '/404') return
-    const pageGroupInfo = getPageGroupInfo(pagePath, pageStaticData, i18n)
-    ensureGroup(pageGroupInfo.group, pageGroupInfo.subGroup).push({
-      pagePath,
-      pageStaticData,
-      pageName: pageGroupInfo.pageName,
-      pageLocale: pageGroupInfo.locale,
-      pageLocaleKey: pageGroupInfo.localeKey,
-    })
-  })
-
-  const rootGroup = groups['/']?.['/']
-  if (rootGroup) {
-    const filtered = rootGroup.filter((page) => {
-      if (page.pageName === '/') return true
-      if (groups[page.pageName]) {
-        // it is explicit grouped
-        if (getStaticDataValue(page.pageStaticData, 'group')) return true
-        // if there is also pages like /guide/start
-        // then /guide should not be grouped with /faq
-        // instead, /guide should be moved to the "guide" group
-        ensureGroup(page.pageName, '/').push(page)
-        return false
-      }
-      return true
-    })
-    groups['/']['/'] = filtered
-  }
-
-  return groups
-}
-
-function getPageGroupInfo(
-  pagePath: string,
-  pageStaticData: any,
-  i18n: I18nConfig | undefined
-): {
-  group: string
-  subGroup: string
-  pageName: string
-  locale: LocalConfig | undefined
-  localeKey: string | undefined
-} {
-  if (!pagePath.startsWith('/'))
-    throw new Error(`expect pagePath.startsWith('/'). pagePath: ${pagePath}`)
-  const { pagePathWithoutLocalePrefix, locale, localeKey } =
-    matchPagePathLocalePrefix(pagePath, i18n)
-  const seg = removeStartSlash(pagePathWithoutLocalePrefix).split('/')
-  let group: string = getStaticDataValue(pageStaticData, 'group')
-  let subGroup: string = getStaticDataValue(pageStaticData, 'subGroup')
-  // used as default title
-  const pageName: string = seg[seg.length - 1] || '/'
-  if (seg.length === 1) {
-    group ||= '/'
-    subGroup ||= '/'
-  } else if (seg.length === 2) {
-    group ||= seg[0]
-    subGroup ||= '/'
-  } else if (seg.length >= 3) {
-    group ||= seg[0]
-    subGroup ||= seg[1]
-  } else {
-    throw new Error('getPageGroup assertion fail')
-  }
-  return {
-    group,
-    subGroup,
-    pageName,
-    locale,
-    localeKey,
-  }
-}
-
-export function matchPagePathLocalePrefix(
-  pagePath: string,
-  i18n: I18nConfig | undefined
-) {
-  const result = {
-    pagePathWithoutLocalePrefix: pagePath,
-    localeKey: undefined as string | undefined,
-    locale: undefined as LocalConfig | undefined,
-  }
-  if (!i18n?.locales) return result
-
-  Object.entries(i18n.locales).forEach(([localeKey, locale]) => {
-    const prefix = locale.routePrefix || ensureStartSlash(localeKey)
-    if (
-      pagePath.startsWith(prefix) &&
-      // routePrefix '/' has lower priority than '/any-prefix'
-      (!result.locale || result.locale.routePrefix === '/')
-    ) {
-      result.pagePathWithoutLocalePrefix = ensureStartSlash(
-        pagePath.slice(prefix.length)
-      )
-      result.localeKey = localeKey
-      result.locale = locale
-    }
-  })
-  // fallback to defaultLocale
-  if (
-    !result.locale &&
-    i18n.defaultLocale &&
-    i18n.locales[i18n.defaultLocale]
-  ) {
-    result.localeKey = i18n.defaultLocale
-    result.locale = i18n.locales[i18n.defaultLocale]
-  }
-  return result
 }

--- a/packages/theme-doc/src/Layout/index.module.less
+++ b/packages/theme-doc/src/Layout/index.module.less
@@ -47,6 +47,12 @@
       display: flex;
       align-items: center;
 
+      .media-width-md({
+        & {
+          min-width: 260px;
+        }
+      });
+
       .logoLink {
         display: inline-block;
         vertical-align: text-bottom;
@@ -55,6 +61,11 @@
           color: #40a9ff;
         }
       }
+    }
+
+    .searchArea {
+      display: flex;
+      align-items: center;
     }
 
     .flexSpace {

--- a/packages/theme-doc/src/ThemeConfig.doc.ts
+++ b/packages/theme-doc/src/ThemeConfig.doc.ts
@@ -4,6 +4,7 @@ import type {
   PagesStaticData,
   ThemeProps,
 } from 'vite-plugin-react-pages/clientTypes'
+import type { PageGroups } from './analyzeStaticData'
 
 export interface ThemeConfig {
   /**
@@ -116,6 +117,7 @@ export type ThemeContextValue = ThemeProps & {
      */
     pagePathWithoutLocalePrefix?: string
   }
+  pageGroups: PageGroups
 }
 
 export type { MenuConfig, FooterConfig, FooterColumn, FooterLink }

--- a/packages/theme-doc/src/analyzeStaticData.ts
+++ b/packages/theme-doc/src/analyzeStaticData.ts
@@ -35,16 +35,16 @@ export function getPageGroups(staticData: any, i18n: I18nConfig | undefined) {
 
   Object.entries(staticData).forEach(([pagePath, pageStaticData]) => {
     if (pagePath === '/404') return
-    const pageGroupInfo = getOnePageGroupInfo(pagePath, pageStaticData, i18n)
-    ensureGroup(pageGroupInfo.group, pageGroupInfo.subGroup).push({
+    const pageInfo = analyzePageInfo(pagePath, pageStaticData, i18n)
+    ensureGroup(pageInfo.group, pageInfo.subGroup).push({
       pageStaticData,
       pagePath,
-      groupKey: pageGroupInfo.group,
-      subGroupKey: pageGroupInfo.subGroup,
-      pageKeyInGroup: pageGroupInfo.pageKeyInGroup,
-      pageTitle: pageGroupInfo.pageTitle,
-      pageLocale: pageGroupInfo.locale,
-      pageLocaleKey: pageGroupInfo.localeKey,
+      groupKey: pageInfo.group,
+      subGroupKey: pageInfo.subGroup,
+      pageKeyInGroup: pageInfo.pageKeyInGroup,
+      pageTitle: pageInfo.pageTitle,
+      pageLocale: pageInfo.locale,
+      pageLocaleKey: pageInfo.localeKey,
     })
   })
 
@@ -69,7 +69,7 @@ export function getPageGroups(staticData: any, i18n: I18nConfig | undefined) {
   return groups
 }
 
-export function getOnePageGroupInfo(
+export function analyzePageInfo(
   pagePath: string,
   pageStaticData: any,
   i18n: I18nConfig | undefined

--- a/packages/theme-doc/src/analyzeStaticData.ts
+++ b/packages/theme-doc/src/analyzeStaticData.ts
@@ -1,0 +1,150 @@
+import type { I18nConfig, LocalConfig } from '.'
+import { ensureStartSlash, getStaticDataValue, removeStartSlash } from './utils'
+
+// map groups -> subgroups -> pages
+export type PageGroups = {
+  [groupKey: string]: {
+    [subGroupKey: string]: PageMeta[]
+  }
+}
+
+export type PageMeta = {
+  pageStaticData: any
+  // pagePath is parsed into three part:
+  // /${groupKey}/${subGroupKey}/${pageKeyInGroup}
+  pagePath: string
+  groupKey: string
+  subGroupKey: string
+  pageKeyInGroup: string
+  // pageTitle is extracted from frontmatter or markdown title
+  // use pageKeyInGroup as fallback
+  pageTitle: string
+  pageLocale: LocalConfig | undefined
+  pageLocaleKey: string | undefined
+}
+
+export function getPageGroups(staticData: any, i18n: I18nConfig | undefined) {
+  const groups: PageGroups = {}
+  function ensureGroup(group: string): Record<string, PageMeta[]>
+  function ensureGroup(group: string, subGroup: string): PageMeta[]
+  function ensureGroup(group: string, subGroup?: string) {
+    const subGroups = (groups[group] ||= {})
+    if (!subGroup) return subGroups
+    return (subGroups[subGroup] ||= [])
+  }
+
+  Object.entries(staticData).forEach(([pagePath, pageStaticData]) => {
+    if (pagePath === '/404') return
+    const pageGroupInfo = getOnePageGroupInfo(pagePath, pageStaticData, i18n)
+    ensureGroup(pageGroupInfo.group, pageGroupInfo.subGroup).push({
+      pageStaticData,
+      pagePath,
+      groupKey: pageGroupInfo.group,
+      subGroupKey: pageGroupInfo.subGroup,
+      pageKeyInGroup: pageGroupInfo.pageKeyInGroup,
+      pageTitle: pageGroupInfo.pageTitle,
+      pageLocale: pageGroupInfo.locale,
+      pageLocaleKey: pageGroupInfo.localeKey,
+    })
+  })
+
+  const rootGroup = groups['/']?.['/']
+  if (rootGroup) {
+    const filtered = rootGroup.filter((page) => {
+      if (page.pageKeyInGroup === '/') return true
+      if (groups[page.pageKeyInGroup]) {
+        // it is explicit grouped
+        if (getStaticDataValue(page.pageStaticData, 'group')) return true
+        // if there is also pages like /guide/start
+        // then /guide should not be grouped with /faq
+        // instead, /guide should be moved to the "guide" group
+        ensureGroup(page.pageKeyInGroup, '/').push(page)
+        return false
+      }
+      return true
+    })
+    groups['/']['/'] = filtered
+  }
+
+  return groups
+}
+
+export function getOnePageGroupInfo(
+  pagePath: string,
+  pageStaticData: any,
+  i18n: I18nConfig | undefined
+): {
+  group: string
+  subGroup: string
+  pageKeyInGroup: string
+  pageTitle: string
+  locale: LocalConfig | undefined
+  localeKey: string | undefined
+} {
+  if (!pagePath.startsWith('/'))
+    throw new Error(`expect pagePath.startsWith('/'). pagePath: ${pagePath}`)
+  const { pagePathWithoutLocalePrefix, locale, localeKey } =
+    matchPagePathLocalePrefix(pagePath, i18n)
+  const seg = removeStartSlash(pagePathWithoutLocalePrefix).split('/')
+  let group: string = getStaticDataValue(pageStaticData, 'group')
+  let subGroup: string = getStaticDataValue(pageStaticData, 'subGroup')
+  // used as default title
+  const pageKeyInGroup: string = seg[seg.length - 1] || '/'
+  if (seg.length === 1) {
+    group ||= '/'
+    subGroup ||= '/'
+  } else if (seg.length === 2) {
+    group ||= seg[0]
+    subGroup ||= '/'
+  } else if (seg.length >= 3) {
+    group ||= seg[0]
+    subGroup ||= seg[1]
+  } else {
+    throw new Error('getPageGroup assertion fail')
+  }
+  return {
+    group,
+    subGroup,
+    pageKeyInGroup,
+    pageTitle: getStaticDataValue(pageStaticData, 'title') ?? pageKeyInGroup,
+    locale,
+    localeKey,
+  }
+}
+
+export function matchPagePathLocalePrefix(
+  pagePath: string,
+  i18n: I18nConfig | undefined
+) {
+  const result = {
+    pagePathWithoutLocalePrefix: pagePath,
+    localeKey: undefined as string | undefined,
+    locale: undefined as LocalConfig | undefined,
+  }
+  if (!i18n?.locales) return result
+
+  Object.entries(i18n.locales).forEach(([localeKey, locale]) => {
+    const prefix = locale.routePrefix || ensureStartSlash(localeKey)
+    if (
+      pagePath.startsWith(prefix) &&
+      // routePrefix '/' has lower priority than '/any-prefix'
+      (!result.locale || result.locale.routePrefix === '/')
+    ) {
+      result.pagePathWithoutLocalePrefix = ensureStartSlash(
+        pagePath.slice(prefix.length)
+      )
+      result.localeKey = localeKey
+      result.locale = locale
+    }
+  })
+  // fallback to defaultLocale
+  if (
+    !result.locale &&
+    i18n.defaultLocale &&
+    i18n.locales[i18n.defaultLocale]
+  ) {
+    result.localeKey = i18n.defaultLocale
+    result.locale = i18n.locales[i18n.defaultLocale]
+  }
+  return result
+}

--- a/packages/theme-doc/src/index.tsx
+++ b/packages/theme-doc/src/index.tsx
@@ -10,8 +10,8 @@ import './style.less'
 import { Demo } from './Layout/Demo'
 import AnchorLink from './components/AnchorLink'
 import type { ThemeConfig, ThemeContextValue } from './ThemeConfig.doc'
-import { matchPagePathLocalePrefix } from './Layout/Sider'
 import { normalizeI18nConfig } from './utils'
+import { getPageGroups, matchPagePathLocalePrefix } from './analyzeStaticData'
 
 export function createTheme(themeConfig: ThemeConfig): React.FC<ThemeProps> {
   const ThemeComp = (props: ThemeProps) => {
@@ -90,14 +90,16 @@ export function createTheme(themeConfig: ThemeConfig): React.FC<ThemeProps> {
       const { loadState, loadedData } = props
       const staticData = useStaticData()
       const themeCtxValue: ThemeContextValue = useMemo(() => {
+        const i18n = normalizeI18nConfig(themeConfig.i18n)
         const result: ThemeContextValue = {
           ...props,
           themeConfig: {
             ...themeConfig,
-            i18n: normalizeI18nConfig(themeConfig.i18n),
+            i18n,
           },
           staticData,
           resolvedLocale: {},
+          pageGroups: getPageGroups(staticData, i18n),
         }
         if (!result.themeConfig.i18n?.locales) return result
         const { locale, localeKey, pagePathWithoutLocalePrefix } =

--- a/packages/theme-doc/src/utils.ts
+++ b/packages/theme-doc/src/utils.ts
@@ -34,3 +34,7 @@ export function normalizeI18nConfig(
   )
   return { ...i18n, locales: newLocales }
 }
+
+export function getStaticDataValue(pageStaticData: any, key: string) {
+  return pageStaticData?.[key] ?? pageStaticData?.main?.[key]
+}


### PR DESCRIPTION
TODO:
- handle I18n seperation (should not show results from other locales)
- support searching in H1, H2, H3 title of markdown pages. Not only page titles.
- support search config like: https://vuepress.vuejs.org/theme/default-theme-config.html#built-in-search
- Responsive design style
- algolia search


Fix: https://github.com/vitejs/vite-plugin-react-pages/issues/52