### PR TITLE
fix: disable some minify options to avoid wrong hydration

### DIFF
--- a/packages/react-pages/src/node/static-site-generation/index.ts
+++ b/packages/react-pages/src/node/static-site-generation/index.ts
@@ -10,9 +10,7 @@ import { CLIENT_PATH } from '../constants'
 import type { SSRPlugin } from '../../../clientTypes'
 
 const minifyOptions = {
-  collapseWhitespace: true,
   keepClosingSlash: true,
-  removeComments: true,
   removeRedundantAttributes: true,
   removeStyleLinkTypeAttributes: true,
   useShortDoctype: true,


### PR DESCRIPTION
[encoutered error](https://reactjs.org/docs/error-decoder.html/?invariant=418) , disable some options to avoid it.