### PR TITLE
fix(theme-doc): some outline styles

### DIFF
--- a/packages/theme-doc/src/Layout/index.module.less
+++ b/packages/theme-doc/src/Layout/index.module.less
@@ -249,7 +249,7 @@
 
     .outline {
       flex: 0 0 auto;
-      width: 180px;
+      width: 300px;
       // border: 5px solid red;
       display: none;
       .media-width-md({
@@ -258,6 +258,10 @@
       .anchors {
         position: sticky;
         top: 100px;
+
+        a:hover {
+          color: #1677ff;
+        }
       }
       padding-bottom: 40px;
     }

--- a/packages/theme-doc/src/Layout/index.module.less
+++ b/packages/theme-doc/src/Layout/index.module.less
@@ -249,7 +249,7 @@
 
     .outline {
       flex: 0 0 auto;
-      width: 300px;
+      width: 220px;
       // border: 5px solid red;
       display: none;
       .media-width-md({


### PR DESCRIPTION
The width of outline is not long enough to display full text of anchors.