### PR TITLE
refactor ts info extract (using ts-morph); support complex type.

### DIFF
--- a/packages/create-project/template-lib-monorepo/packages/button/README.md
+++ b/packages/create-project/template-lib-monorepo/packages/button/README.md
@@ -17,9 +17,11 @@ You can import demos like this:
 
 <Demo src="./demos/demo2.tsx" />
 
-## Extract API info from Typescript code
+## Extract Type info from Typescript code
 
-You can extract API from Typescript interface and render it into page.
+You can extract Typescript type info and render it into page. This is very useful for API documentation.
+
+### Render Interface
 
 The following markdown
 
@@ -33,7 +35,19 @@ will result in:
 
 <TsInfo src="./src/types.ts" name="ButtonProps" />
 
-In jsx page, You can render TsInfo like this:
+### Render Type Alias
+
+Besides interface, TsInfo API also support type alias.
+
+SomeObjectLiteralType (Object Literal):
+<TsInfo src="./src/types.ts" name="SomeObjectLiteralType" />
+
+SomeComplexType (Complex Type):
+<TsInfo src="./src/types.ts" name="SomeComplexType" />
+
+### Using TsInfo API in JS files
+
+In jsx page, You can import and render tsInfo like this:
 
 ```tsx
 import tsInfoData from './types.ts?tsInfo=ButtonProps'

--- a/packages/create-project/template-lib-monorepo/packages/button/src/types.ts
+++ b/packages/create-project/template-lib-monorepo/packages/button/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * This is the description of the Button component's props
  */
-export interface ButtonProps {
+export interface ButtonProps<TestGenerics extends string> extends Base {
   /**
    * the type of button
    * @defaultValue 'default'
@@ -11,7 +11,7 @@ export interface ButtonProps {
    * the size of button
    * @defaultValue 'middle'
    */
-  size?: 'large' | 'middle' | 'small'
+  size?: 'large' | 'middle' | 'small' | TestGenerics
   /**
    * loading state of button
    * @defaultValue false
@@ -21,8 +21,46 @@ export interface ButtonProps {
    * click handler
    */
   onClick?: (event: React.MouseEvent) => void
+  /** test method declaration */
+  testMethod(param: string): void
+  /** test required property */
+  testRequired: boolean
+}
+
+interface Base {
   /**
-   * button content
+   * children content
    */
   children: React.ReactNode
 }
+
+export type SomeObjectLiteralType<TestGenerics> = {
+  /**
+   * the type of button
+   * @defaultValue 'default'
+   */
+  type?: 'primary' | 'default' | 'text'
+  /**
+   * the size of button
+   * @defaultValue 'middle'
+   */
+  size?: 'large' | 'middle' | 'small' | TestGenerics
+  /**
+   * loading state of button
+   * @defaultValue false
+   */
+  loading?: boolean
+  /**
+   * click handler
+   */
+  onClick?: (event: React.MouseEvent) => void
+  /** test method declaration */
+  testMethod(param: string): void
+  /** test required property */
+  testRequired: boolean
+}
+
+/**
+ * Description of SomeComplexType ...
+ */
+export type SomeComplexType = 0 | 1 | 'a' | 'b' | { key: string }

--- a/packages/create-project/template-lib/src/Button/README.md
+++ b/packages/create-project/template-lib/src/Button/README.md
@@ -17,9 +17,11 @@ You can import demos like this:
 
 <Demo src="./demos/demo2.tsx" />
 
-## Extract API info from Typescript code
+## Extract Type info from Typescript code
 
-You can extract API from Typescript interface and render it into page.
+You can extract Typescript type info and render it into page. This is very useful for API documentation.
+
+### Render Interface
 
 The following markdown
 
@@ -33,7 +35,19 @@ will result in:
 
 <TsInfo src="./types.ts" name="ButtonProps" />
 
-In jsx page, You can render TsInfo like this:
+### Render Type Alias
+
+Besides interface, TsInfo API also support type alias.
+
+SomeObjectLiteralType (Object Literal):
+<TsInfo src="./types.ts" name="SomeObjectLiteralType" />
+
+SomeComplexType (Complex Type):
+<TsInfo src="./types.ts" name="SomeComplexType" />
+
+### Using TsInfo API in JS files
+
+In jsx page, You can import and render tsInfo like this:
 
 ```tsx
 import tsInfoData from './types.ts?tsInfo=ButtonProps'

--- a/packages/create-project/template-lib/src/Button/types.ts
+++ b/packages/create-project/template-lib/src/Button/types.ts
@@ -1,7 +1,7 @@
 /**
  * This is the description of the Button component's props
  */
-export interface ButtonProps {
+export interface ButtonProps<TestGenerics extends string> extends Base {
   /**
    * the type of button
    * @defaultValue 'default'
@@ -11,7 +11,7 @@ export interface ButtonProps {
    * the size of button
    * @defaultValue 'middle'
    */
-  size?: 'large' | 'middle' | 'small'
+  size?: 'large' | 'middle' | 'small' | TestGenerics
   /**
    * loading state of button
    * @defaultValue false
@@ -21,8 +21,46 @@ export interface ButtonProps {
    * click handler
    */
   onClick?: (event: React.MouseEvent) => void
+  /** test method declaration */
+  testMethod(param: string): void
+  /** test required property */
+  testRequired: boolean
+}
+
+interface Base {
   /**
-   * button content
+   * children content
    */
   children: React.ReactNode
 }
+
+export type SomeObjectLiteralType<TestGenerics> = {
+  /**
+   * the type of button
+   * @defaultValue 'default'
+   */
+  type?: 'primary' | 'default' | 'text'
+  /**
+   * the size of button
+   * @defaultValue 'middle'
+   */
+  size?: 'large' | 'middle' | 'small' | TestGenerics
+  /**
+   * loading state of button
+   * @defaultValue false
+   */
+  loading?: boolean
+  /**
+   * click handler
+   */
+  onClick?: (event: React.MouseEvent) => void
+  /** test method declaration */
+  testMethod(param: string): void
+  /** test required property */
+  testRequired: boolean
+}
+
+/**
+ * Description of SomeComplexType ...
+ */
+export type SomeComplexType = 0 | 1 | 'a' | 'b' | { key: string }

--- a/packages/playground/use-theme-doc/pages/components/button/index$.md
+++ b/packages/playground/use-theme-doc/pages/components/button/index$.md
@@ -8,8 +8,14 @@ subGroup: general
 demo1:
 <Demo src="./demos/demo1.tsx" />
 
-ButtonProps:
+ButtonProps (Interface):
 <TsInfo src="./types.ts" name="ButtonProps" />
 
-ButtonProps by FileText:
+SomeObjectLiteralType (Object Literal):
+<TsInfo src="./types.ts" name="SomeObjectLiteralType" />
+
+SomeComplexType (Complex Type):
+<TsInfo src="./types.ts" name="SomeComplexType" />
+
+FileText:
 <FileText src="./types.ts" syntax="ts" />

--- a/packages/playground/use-theme-doc/pages/components/button/types.ts
+++ b/packages/playground/use-theme-doc/pages/components/button/types.ts
@@ -1,7 +1,7 @@
 /**
  * This is the description of the Button component's props
  */
-export interface ButtonProps<TestGenerics extends string> {
+export interface ButtonProps<TestGenerics extends string> extends Base {
   /**
    * the type of button
    * @defaultValue 'default'
@@ -21,8 +21,46 @@ export interface ButtonProps<TestGenerics extends string> {
    * click handler
    */
   onClick?: (event: React.MouseEvent) => void
+  /** test method declaration */
+  testMethod(param: string): void
+  /** test required property */
+  testRequired: boolean
+}
+
+interface Base {
   /**
-   * button content
+   * children content
    */
   children: React.ReactNode
 }
+
+export type SomeObjectLiteralType<TestGenerics> = {
+  /**
+   * the type of button
+   * @defaultValue 'default'
+   */
+  type?: 'primary' | 'default' | 'text'
+  /**
+   * the size of button
+   * @defaultValue 'middle'
+   */
+  size?: 'large' | 'middle' | 'small' | TestGenerics
+  /**
+   * loading state of button
+   * @defaultValue false
+   */
+  loading?: boolean
+  /**
+   * click handler
+   */
+  onClick?: (event: React.MouseEvent) => void
+  /** test method declaration */
+  testMethod(param: string): void
+  /** test required property */
+  testRequired: boolean
+}
+
+/**
+ * Description of SomeComplexType ...
+ */
+export type SomeComplexType = 0 | 1 | 'a' | 'b' | { key: string }

--- a/packages/react-pages/clientTypes.d.ts
+++ b/packages/react-pages/clientTypes.d.ts
@@ -11,21 +11,34 @@ export interface PagesInternal {
 }
 
 // the result of tsInfo extraction
-export interface TsInterfaceInfo {
+export type TsInfo =
+  | {
+      // example: type A = { k: v }
+      type: 'object-literal'
+      name: string
+      description: string
+      properties: TsPropertyOrMethodInfo[]
+    }
+  | {
+      // example: interface MyInterface { k: v }
+      type: 'interface'
+      name: string
+      description: string
+      properties: TsPropertyOrMethodInfo[]
+    }
+  | {
+      // complex type literal
+      // example: type A = 'asd' | 123
+      type: 'other'
+      name: string
+      description: string
+      text: string
+    }
+export interface TsPropertyOrMethodInfo {
   name: string
-  // commentText: string
-  description: string
-  // fullText: string
-  properties: TsInterfacePropertyInfo[]
-}
-
-export interface TsInterfacePropertyInfo {
-  name: string
-  // commentText: string
   type: string
   description: string
   defaultValue: string | undefined
-  // fullText: string
   optional: boolean
 }
 

--- a/packages/react-pages/package.json
+++ b/packages/react-pages/package.json
@@ -88,6 +88,7 @@
     "remark-mdx-images": "^2.0.0",
     "slash": "^3.0.0",
     "tiny-invariant": "^1.3.1",
+    "ts-morph": "^17.0.1",
     "typescript": "^4.9.4",
     "unist-util-visit": "^4.1.1"
   }

--- a/packages/react-pages/src/node/index.ts
+++ b/packages/react-pages/src/node/index.ts
@@ -234,8 +234,8 @@ export type {
   LoadState,
   PagesLoaded,
   PagesStaticData,
-  TsInterfaceInfo,
-  TsInterfacePropertyInfo,
+  TsInfo,
+  TsPropertyOrMethodInfo,
 } from '../../clientTypes'
 
 export type { FileHandler } from './page-strategy/types.doc'

--- a/packages/react-pages/src/node/virtual-module-plugins/demo-modules/mdx-plugin.ts
+++ b/packages/react-pages/src/node/virtual-module-plugins/demo-modules/mdx-plugin.ts
@@ -28,7 +28,7 @@ export function DemoMdxPlugin() {
           const nextIndex = addImports.length
           const varName = `_demo${nextIndex}`
           // add import:
-          // import * as varName from "${srcValue}?tsInfo=${nameValue}"
+          // import * as varName from "${srcValue}?demo"
           addImports.push(
             createNameSpaceImportNode({
               name: varName,

--- a/packages/theme-doc/src/Layout/Demo/index.tsx
+++ b/packages/theme-doc/src/Layout/Demo/index.tsx
@@ -27,7 +27,7 @@ export function Demo({
   if (!DemoComp || !demoMeta || !isDemo) {
     return (
       <pre>{`Demo Error: <Demo> component receives invalid props.
-If you use it in jsx, you should import demos like "import * as demoInfo from './demos/demo.tsx?demo'" and use it like "<Demo {...demoInfo}>"
+If you use it in jsx, you should import demoInfo like "import * as demoInfo from './demos/demo.tsx?demo'" and render it like "<Demo {...demoInfo}>"
 If you use it in markdown, you should use it exactly like "<Demo src="./demos/demo1.tsx" />" (we use simple regexp to parse it, so you should use this format strictly)
 `}</pre>
     )

--- a/packages/theme-doc/src/Layout/TsInfo/index.module.css
+++ b/packages/theme-doc/src/Layout/TsInfo/index.module.css
@@ -1,5 +1,5 @@
 .table.table.table {
-  margin-top: 24px;
+  margin: 16px 0px;
   display: table;
 }
 

--- a/packages/theme-doc/src/Layout/TsInfo/index.tsx
+++ b/packages/theme-doc/src/Layout/TsInfo/index.tsx
@@ -1,53 +1,77 @@
 import React from 'react'
-import type { TsInterfaceInfo } from 'vite-plugin-react-pages/clientTypes'
+import type { TsInfo as TsInfoData } from 'vite-plugin-react-pages/clientTypes'
 
 import s from './index.module.css'
 
 interface Props {
-  data: TsInterfaceInfo
+  data: TsInfoData
 }
 
 export function TsInfo({ data }: Props) {
-  if (!data?.properties) {
+  if (data.type === 'interface' || data.type === 'object-literal') {
     return (
-      <pre>{`TsInfo Error: <TsInfo> component receives invalid props.
-If you use it in jsx, you should import demos like "import * as tsInfo from './path/to/type.ts?tsInfo=InterfaceName'" and use it like "<TsInfo {...tsInfo}>"
-If you use it in markdown, you should use it exactly like "<TsInfo src="./path/to/type.ts" name="ButtonProps" />" (we use simple regexp to parse it, so you should use this format strictly)
-`}</pre>
+      <table className={s.table}>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Type</th>
+            <th>Default Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.properties.map((row) => {
+            const type = row.type.trim()
+            const defaultValue = (() => {
+              if (row.defaultValue) return <code>{row.defaultValue}</code>
+              if (row.optional) return ''
+              return (
+                <span>
+                  Required<span style={{ color: 'red' }}>*</span>
+                </span>
+              )
+            })()
+            return (
+              <tr key={row.name}>
+                <td>{row.name}</td>
+                <td>{row.description}</td>
+                <td>{type && <code>{type}</code>}</td>
+                <td>{defaultValue}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
     )
   }
+
+  if (data.type === 'other') {
+    return (
+      <table className={s.table}>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{data.name}</td>
+            <td>{data.description}</td>
+            <td>
+              <pre>{data.text}</pre>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    )
+  }
+
   return (
-    <table className={s.table}>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Description</th>
-          <th>Type</th>
-          <th>Default Value</th>
-        </tr>
-      </thead>
-      <tbody>
-        {data.properties.map((row) => {
-          const type = row.type.trim()
-          const defaultValue = (() => {
-            if (row.defaultValue) return <code>{row.defaultValue}</code>
-            if (row.optional) return ''
-            return (
-              <span>
-                Required<span style={{ color: 'red' }}>*</span>
-              </span>
-            )
-          })()
-          return (
-            <tr key={row.name}>
-              <td>{row.name}</td>
-              <td>{row.description}</td>
-              <td>{type && <code>{type}</code>}</td>
-              <td>{defaultValue}</td>
-            </tr>
-          )
-        })}
-      </tbody>
-    </table>
+    <pre>{`TsInfo Error: <TsInfo> component receives invalid props.
+If you use it in jsx, you should import tsInfo like "import * as tsInfo from './path/to/type.ts?tsInfo=InterfaceName'" and render it like "<TsInfo {...tsInfo}>"
+If you use it in markdown, you should use it exactly like "<TsInfo src="./path/to/type.ts" name="ButtonProps" />" (we use simple regexp to parse it, so you should use this format strictly)
+`}</pre>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,7 @@ importers:
       rollup: ^3.7.5
       slash: ^3.0.0
       tiny-invariant: ^1.3.1
+      ts-morph: ^17.0.1
       typescript: ^4.9.4
       unist-util-visit: ^4.1.1
       vite: ^4.2.1
@@ -433,6 +434,7 @@ importers:
       remark-mdx-images: 2.0.0
       slash: 3.0.0
       tiny-invariant: 1.3.1
+      ts-morph: 17.0.1
       typescript: 4.9.4
       unist-util-visit: 4.1.1
     devDependencies:
@@ -3707,12 +3709,10 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-    dev: true
 
   /@nodelib/fs.stat/2.0.5:
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
-    dev: true
 
   /@nodelib/fs.walk/1.2.8:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
@@ -3720,7 +3720,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.14.0
-    dev: true
 
   /@playwright/test/1.29.0:
     resolution: {integrity: sha512-gp5PVBenxTJsm2bATWDNc2CCnrL5OaA/MXQdJwwkGQtqTjmY+ZOqAdLqo49O9MLTDh2vYh+tHWDnmFsILnWaeA==}
@@ -4113,6 +4112,15 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
     dev: true
+
+  /@ts-morph/common/0.18.1:
+    resolution: {integrity: sha512-RVE+zSRICWRsfrkAw5qCAK+4ZH9kwEFv5h0+/YeHTLieWP7F4wWq4JsKFuNWG+fYh/KF+8rAtgdj5zb2mm+DVA==}
+    dependencies:
+      fast-glob: 3.2.12
+      minimatch: 5.1.1
+      mkdirp: 1.0.4
+      path-browserify: 1.0.1
+    dev: false
 
   /@types/acorn/4.0.6:
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -4536,7 +4544,6 @@ packages:
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /better-path-resolve/1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -4595,7 +4602,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -4801,6 +4807,10 @@ packages:
     resolution: {integrity: sha512-wx+RWLgiSU6SCDzMtxG0Dv1lsuOcEfqq5SbqAViezaJIkR5sbveKzFU31YnWhqrJx3o3Iu3H0Rq8R00OS3oI+Q==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: true
+
+  /code-block-writer/11.0.3:
+    resolution: {integrity: sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==}
+    dev: false
 
   /color-convert/1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -5375,7 +5385,6 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
-    dev: true
 
   /fast-safe-stringify/2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -5391,7 +5400,6 @@ packages:
     resolution: {integrity: sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==}
     dependencies:
       reusify: 1.0.4
-    dev: true
 
   /fault/2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
@@ -6473,7 +6481,6 @@ packages:
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-    dev: true
 
   /micromark-core-commonmark/1.0.6:
     resolution: {integrity: sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==}
@@ -6793,7 +6800,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-    dev: true
 
   /mime-db/1.33.0:
     resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
@@ -6852,7 +6858,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
@@ -6860,6 +6865,12 @@ packages:
 
   /minimist/1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
+
+  /mkdirp/1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: false
 
   /mri/1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -7115,6 +7126,10 @@ packages:
     dependencies:
       no-case: 3.0.4
       tslib: 2.4.1
+    dev: false
+
+  /path-browserify/1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
     dev: false
 
   /path-exists/3.0.0:
@@ -7652,7 +7667,6 @@ packages:
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
 
   /range-parser/1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
@@ -8628,7 +8642,6 @@ packages:
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
 
   /rfdc/1.3.0:
     resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
@@ -8690,7 +8703,6 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-    dev: true
 
   /rxjs/7.5.5:
     resolution: {integrity: sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==}
@@ -9184,6 +9196,13 @@ packages:
 
   /trough/2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
+
+  /ts-morph/17.0.1:
+    resolution: {integrity: sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g==}
+    dependencies:
+      '@ts-morph/common': 0.18.1
+      code-block-writer: 11.0.3
+    dev: false
 
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}


### PR DESCRIPTION
Use https://github.com/dsherret/ts-morph to extract ts info. 
Checkout Button component document in the demo/template.

Fix: https://github.com/vitejs/vite-plugin-react-pages/issues/117