### PR TITLE
chore: update vite and rollup

### DIFF
--- a/doc-site/package.json
+++ b/doc-site/package.json
@@ -28,7 +28,7 @@
     "gh-pages": "^5.0.0",
     "rimraf": "^4.4.1",
     "serve": "^14.2.0",
-    "vite": "^4.3.9",
+    "vite": "^4.4.8",
     "vite-pages-theme-doc": "workspace:*",
     "vite-plugin-react-pages": "workspace:*"
   }

--- a/packages/create-project/template-app/package.json
+++ b/packages/create-project/template-app/package.json
@@ -23,7 +23,7 @@
     "@vitejs/plugin-react": "^4.0.1",
     "rimraf": "^4.4.1",
     "serve": "^14.2.0",
-    "vite": "^4.3.9",
+    "vite": "^4.4.8",
     "vite-pages-theme-doc": "^4.0.0",
     "vite-plugin-react-pages": "^4.0.0"
   }

--- a/packages/create-project/template-lib-monorepo/packages/demos/package.json
+++ b/packages/create-project/template-lib-monorepo/packages/demos/package.json
@@ -26,7 +26,7 @@
     "my-card": "*",
     "rimraf": "^4.4.1",
     "serve": "^14.2.0",
-    "vite": "^4.3.9",
+    "vite": "^4.4.8",
     "vite-pages-theme-doc": "^4.0.0",
     "vite-plugin-react-pages": "^4.0.0"
   }

--- a/packages/create-project/template-lib/package.json
+++ b/packages/create-project/template-lib/package.json
@@ -22,7 +22,7 @@
     "@vitejs/plugin-react": "^4.0.1",
     "rimraf": "^4.4.1",
     "serve": "^14.2.0",
-    "vite": "^4.3.9",
+    "vite": "^4.4.8",
     "vite-pages-theme-doc": "^4.0.0",
     "vite-plugin-react-pages": "^4.0.0"
   }

--- a/packages/playground/basic/package.json
+++ b/packages/playground/basic/package.json
@@ -23,7 +23,7 @@
     "rimraf": "^4.4.1",
     "sass": "^1.63.6",
     "serve": "^14.2.0",
-    "vite": "^4.3.9",
+    "vite": "^4.4.8",
     "vite-plugin-react-pages": "workspace:*"
   }
 }

--- a/packages/playground/custom-find-pages/package.json
+++ b/packages/playground/custom-find-pages/package.json
@@ -24,7 +24,7 @@
     "@vitejs/plugin-react": "^4.0.1",
     "rimraf": "^4.4.1",
     "serve": "^14.2.0",
-    "vite": "^4.3.9",
+    "vite": "^4.4.8",
     "vite-pages-theme-doc": "workspace:*",
     "vite-plugin-react-pages": "workspace:*"
   }

--- a/packages/playground/custom-find-pages2/package.json
+++ b/packages/playground/custom-find-pages2/package.json
@@ -24,7 +24,7 @@
     "@vitejs/plugin-react": "^4.0.1",
     "rimraf": "^4.4.1",
     "serve": "^14.2.0",
-    "vite": "^4.3.9",
+    "vite": "^4.4.8",
     "vite-pages-theme-doc": "workspace:*",
     "vite-plugin-react-pages": "workspace:*"
   }

--- a/packages/playground/lib-monorepo/packages/demos/package.json
+++ b/packages/playground/lib-monorepo/packages/demos/package.json
@@ -23,7 +23,7 @@
     "playground-card": "*",
     "rimraf": "^4.4.1",
     "serve": "^14.2.0",
-    "vite": "^4.3.9",
+    "vite": "^4.4.8",
     "vite-pages-theme-doc": "workspace:*",
     "vite-plugin-react-pages": "workspace:*"
   }

--- a/packages/playground/use-theme-doc/package.json
+++ b/packages/playground/use-theme-doc/package.json
@@ -26,7 +26,7 @@
     "@vitejs/plugin-react-swc": "^3.3.2",
     "rimraf": "^4.4.1",
     "serve": "^14.2.0",
-    "vite": "^4.3.9",
+    "vite": "^4.4.8",
     "vite-pages-theme-doc": "workspace:*",
     "vite-plugin-react-pages": "workspace:*"
   }

--- a/packages/react-pages/package.json
+++ b/packages/react-pages/package.json
@@ -61,9 +61,9 @@
     "concurrently": "^7.6.0",
     "react": "^18.2.0",
     "rimraf": "^4.4.1",
-    "rollup": "^3.25.1",
+    "rollup": "^3.27.0",
     "typescript": "^4.3.2",
-    "vite": "^4.3.9"
+    "vite": "^4.4.8"
   },
   "dependencies": {
     "@mdx-js/rollup": "^2.3.0",

--- a/packages/react-pages/src/node/index.ts
+++ b/packages/react-pages/src/node/index.ts
@@ -1,7 +1,11 @@
 import * as path from 'path'
 import type { PluggableList } from 'unified'
-import type { Plugin, IndexHtmlTransformContext, PluginOption } from 'vite'
-import type { OutputPlugin } from 'rollup'
+import type {
+  Plugin,
+  IndexHtmlTransformContext,
+  PluginOption,
+  Rollup,
+} from 'vite'
 import type { staticSiteGenerationConfig } from './types'
 
 import {
@@ -347,7 +351,7 @@ function createMdxTransformPlugin(): Plugin {
         // https://github.com/vitejs/vite-plugin-react/blob/caa9b5330092c70288fcb94ceb96ca42438df2a2/packages/plugin-react/src/index.ts#L170
         const newFilePath = filepath.replace(/\.mdx?$/, '.jsx')
         const newId = [newFilePath, ...qs].join('?')
-        
+
         return (vitePluginReactTrasnform as any)(code, newId, options)
       }
     },
@@ -358,7 +362,7 @@ function createMdxTransformPlugin(): Plugin {
  * Some chunk filenames may start with `_`, which will be treated as special resource by github pages. So we need to disable jekyll of github pages.
  * https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/
  */
-function outputPluginDisableJekyll(): OutputPlugin {
+function outputPluginDisableJekyll(): Rollup.OutputPlugin {
   return {
     name: 'vite-pages-disable-jekyll',
     generateBundle() {

--- a/packages/theme-doc/package.json
+++ b/packages/theme-doc/package.json
@@ -64,7 +64,7 @@
     "prism-react-renderer": "^1.3.5",
     "rc-footer": "^0.6.8",
     "rimraf": "^4.4.1",
-    "rollup": "^3.25.1",
+    "rollup": "^3.27.0",
     "rollup-plugin-postcss": "^4.0.0",
     "tslib": "^2.5.3",
     "typescript": "^5.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         version: 18.2.13
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.3.9)
+        version: 4.0.1(vite@4.4.8)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -92,8 +92,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
       vite-pages-theme-doc:
         specifier: workspace:*
         version: link:../packages/theme-doc
@@ -133,7 +133,7 @@ importers:
         version: 18.2.13
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.3.9)
+        version: 4.0.1(vite@4.4.8)
       rimraf:
         specifier: ^4.4.1
         version: 4.4.1
@@ -141,8 +141,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
       vite-pages-theme-doc:
         specifier: workspace:*
         version: link:../../theme-doc
@@ -176,7 +176,7 @@ importers:
         version: 18.2.13
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.3.9)
+        version: 4.0.1(vite@4.4.8)
       rimraf:
         specifier: ^4.4.1
         version: 4.4.1
@@ -184,8 +184,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
       vite-pages-theme-doc:
         specifier: workspace:*
         version: link:../../theme-doc
@@ -248,7 +248,7 @@ importers:
         version: 18.2.13
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.3.9)
+        version: 4.0.1(vite@4.4.8)
       globby:
         specifier: ^13.2.0
         version: 13.2.0
@@ -265,8 +265,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
       vite-pages-theme-doc:
         specifier: workspace:*
         version: link:../../../../theme-doc
@@ -298,7 +298,7 @@ importers:
         version: 18.2.13
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.3.9)
+        version: 4.0.1(vite@4.4.8)
       rimraf:
         specifier: ^4.4.1
         version: 4.4.1
@@ -309,8 +309,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
       vite-plugin-react-pages:
         specifier: workspace:*
         version: link:../../react-pages
@@ -332,7 +332,7 @@ importers:
         version: 18.2.13
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.3.9)
+        version: 4.0.1(vite@4.4.8)
       rimraf:
         specifier: ^4.4.1
         version: 4.4.1
@@ -340,8 +340,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
       vite-pages-theme-doc:
         specifier: workspace:*
         version: link:../../theme-doc
@@ -366,7 +366,7 @@ importers:
         version: 18.2.13
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.3.9)
+        version: 4.0.1(vite@4.4.8)
       rimraf:
         specifier: ^4.4.1
         version: 4.4.1
@@ -374,8 +374,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
       vite-pages-theme-doc:
         specifier: workspace:*
         version: link:../../theme-doc
@@ -432,7 +432,7 @@ importers:
         version: 18.2.13
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.3.9)
+        version: 4.0.1(vite@4.4.8)
       globby:
         specifier: ^13.2.0
         version: 13.2.0
@@ -449,8 +449,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
       vite-pages-theme-doc:
         specifier: workspace:*
         version: link:../../../../theme-doc
@@ -475,10 +475,10 @@ importers:
         version: 18.2.13
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.3.9)
+        version: 4.0.1(vite@4.4.8)
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
-        version: 3.3.2(vite@4.3.9)
+        version: 3.3.2(vite@4.4.8)
       rimraf:
         specifier: ^4.4.1
         version: 4.4.1
@@ -486,8 +486,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
       vite-pages-theme-doc:
         specifier: workspace:*
         version: link:../../theme-doc
@@ -501,7 +501,7 @@ importers:
     dependencies:
       '@mdx-js/rollup':
         specifier: ^2.3.0
-        version: 2.3.0(rollup@3.25.1)
+        version: 2.3.0(rollup@3.27.0)
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -583,16 +583,16 @@ importers:
         version: 7.22.5(@babel/core@7.22.5)
       '@rollup/plugin-babel':
         specifier: ^6.0.3
-        version: 6.0.3(@babel/core@7.22.5)(rollup@3.25.1)
+        version: 6.0.3(@babel/core@7.22.5)(rollup@3.27.0)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.2
-        version: 25.0.2(rollup@3.25.1)
+        version: 25.0.2(rollup@3.27.0)
       '@rollup/plugin-node-resolve':
         specifier: ^15.1.0
-        version: 15.1.0(rollup@3.25.1)
+        version: 15.1.0(rollup@3.27.0)
       '@rollup/plugin-typescript':
         specifier: ^11.1.1
-        version: 11.1.1(rollup@3.25.1)(tslib@2.5.3)(typescript@5.1.3)
+        version: 11.1.1(rollup@3.27.0)(tslib@2.5.3)(typescript@5.1.3)
       '@types/fs-extra':
         specifier: ^11.0.1
         version: 11.0.1
@@ -618,11 +618,11 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       rollup:
-        specifier: ^3.25.1
-        version: 3.25.1
+        specifier: ^3.27.0
+        version: 3.27.0
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+        specifier: ^4.4.8
+        version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
 
   packages/theme-doc:
     devDependencies:
@@ -640,16 +640,16 @@ importers:
         version: 7.22.5(@babel/core@7.22.5)
       '@rollup/plugin-babel':
         specifier: ^6.0.3
-        version: 6.0.3(@babel/core@7.22.5)(rollup@3.25.1)
+        version: 6.0.3(@babel/core@7.22.5)(rollup@3.27.0)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.2
-        version: 25.0.2(rollup@3.25.1)
+        version: 25.0.2(rollup@3.27.0)
       '@rollup/plugin-node-resolve':
         specifier: ^15.1.0
-        version: 15.1.0(rollup@3.25.1)
+        version: 15.1.0(rollup@3.27.0)
       '@rollup/plugin-typescript':
         specifier: ^11.1.1
-        version: 11.1.1(rollup@3.25.1)(tslib@2.5.3)(typescript@5.1.3)
+        version: 11.1.1(rollup@3.27.0)(tslib@2.5.3)(typescript@5.1.3)
       '@types/mdx':
         specifier: ^2.0.5
         version: 2.0.5
@@ -699,8 +699,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       rollup:
-        specifier: ^3.25.1
-        version: 3.25.1
+        specifier: ^3.27.0
+        version: 3.27.0
       rollup-plugin-postcss:
         specifier: ^4.0.0
         version: 4.0.2(postcss@8.4.24)(ts-node@10.9.1)
@@ -2442,8 +2442,8 @@ packages:
     resolution: {integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==}
     dev: true
 
-  /@esbuild/android-arm64@0.17.19:
-    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
+  /@esbuild/android-arm64@0.18.17:
+    resolution: {integrity: sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -2451,8 +2451,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.17.19:
-    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
+  /@esbuild/android-arm@0.18.17:
+    resolution: {integrity: sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -2460,8 +2460,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.17.19:
-    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
+  /@esbuild/android-x64@0.18.17:
+    resolution: {integrity: sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -2469,8 +2469,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.17.19:
-    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
+  /@esbuild/darwin-arm64@0.18.17:
+    resolution: {integrity: sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -2478,8 +2478,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.17.19:
-    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
+  /@esbuild/darwin-x64@0.18.17:
+    resolution: {integrity: sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -2487,8 +2487,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.17.19:
-    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
+  /@esbuild/freebsd-arm64@0.18.17:
+    resolution: {integrity: sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -2496,8 +2496,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.17.19:
-    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
+  /@esbuild/freebsd-x64@0.18.17:
+    resolution: {integrity: sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -2505,8 +2505,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.17.19:
-    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
+  /@esbuild/linux-arm64@0.18.17:
+    resolution: {integrity: sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -2514,8 +2514,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.17.19:
-    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
+  /@esbuild/linux-arm@0.18.17:
+    resolution: {integrity: sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -2523,8 +2523,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.17.19:
-    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
+  /@esbuild/linux-ia32@0.18.17:
+    resolution: {integrity: sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -2532,8 +2532,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.17.19:
-    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
+  /@esbuild/linux-loong64@0.18.17:
+    resolution: {integrity: sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -2541,8 +2541,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.17.19:
-    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
+  /@esbuild/linux-mips64el@0.18.17:
+    resolution: {integrity: sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -2550,8 +2550,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.17.19:
-    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
+  /@esbuild/linux-ppc64@0.18.17:
+    resolution: {integrity: sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -2559,8 +2559,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.17.19:
-    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
+  /@esbuild/linux-riscv64@0.18.17:
+    resolution: {integrity: sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -2568,8 +2568,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.17.19:
-    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
+  /@esbuild/linux-s390x@0.18.17:
+    resolution: {integrity: sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -2577,8 +2577,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.17.19:
-    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
+  /@esbuild/linux-x64@0.18.17:
+    resolution: {integrity: sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -2586,8 +2586,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.17.19:
-    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
+  /@esbuild/netbsd-x64@0.18.17:
+    resolution: {integrity: sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -2595,8 +2595,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.17.19:
-    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
+  /@esbuild/openbsd-x64@0.18.17:
+    resolution: {integrity: sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -2604,8 +2604,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.17.19:
-    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
+  /@esbuild/sunos-x64@0.18.17:
+    resolution: {integrity: sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -2613,8 +2613,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.17.19:
-    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
+  /@esbuild/win32-arm64@0.18.17:
+    resolution: {integrity: sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -2622,8 +2622,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.17.19:
-    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
+  /@esbuild/win32-ia32@0.18.17:
+    resolution: {integrity: sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -2631,8 +2631,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.17.19:
-    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
+  /@esbuild/win32-x64@0.18.17:
+    resolution: {integrity: sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -2733,7 +2733,7 @@ packages:
       react: 18.2.0
     dev: true
 
-  /@mdx-js/rollup@2.3.0(rollup@3.25.1):
+  /@mdx-js/rollup@2.3.0(rollup@3.27.0):
     resolution: {integrity: sha512-wLvRfJS/M4UmdqTd+WoaySEE7q4BIejYf1xAHXYvtT1du/1Tl/z2450Gg2+Hu7fh05KwRRiehiTP9Yc/Dtn0fA==}
     peerDependencies:
       rollup: '>=2'
@@ -2742,8 +2742,8 @@ packages:
         optional: true
     dependencies:
       '@mdx-js/mdx': 2.3.0
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
-      rollup: 3.25.1
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      rollup: 3.27.0
       source-map: 0.7.4
       vfile: 5.3.7
     transitivePeerDependencies:
@@ -3046,7 +3046,7 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /@rollup/plugin-babel@6.0.3(@babel/core@7.22.5)(rollup@3.25.1):
+  /@rollup/plugin-babel@6.0.3(@babel/core@7.22.5)(rollup@3.27.0):
     resolution: {integrity: sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3063,11 +3063,11 @@ packages:
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-module-imports': 7.18.6
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
-      rollup: 3.25.1
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      rollup: 3.27.0
     dev: true
 
-  /@rollup/plugin-commonjs@25.0.2(rollup@3.25.1):
+  /@rollup/plugin-commonjs@25.0.2(rollup@3.27.0):
     resolution: {integrity: sha512-NGTwaJxIO0klMs+WSFFtBP7b9TdTJ3K76HZkewT8/+yHzMiUGVQgaPtLQxNVYIgT5F7lxkEyVID+yS3K7bhCow==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3076,16 +3076,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.25.1
+      rollup: 3.27.0
     dev: true
 
-  /@rollup/plugin-node-resolve@15.1.0(rollup@3.25.1):
+  /@rollup/plugin-node-resolve@15.1.0(rollup@3.27.0):
     resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3094,16 +3094,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.2
-      rollup: 3.25.1
+      rollup: 3.27.0
     dev: true
 
-  /@rollup/plugin-typescript@11.1.1(rollup@3.25.1)(tslib@2.5.3)(typescript@5.1.3):
+  /@rollup/plugin-typescript@11.1.1(rollup@3.27.0)(tslib@2.5.3)(typescript@5.1.3):
     resolution: {integrity: sha512-Ioir+x5Bejv72Lx2Zbz3/qGg7tvGbxQZALCLoJaGrkNXak/19+vKgKYJYM3i/fJxvsb23I9FuFQ8CUBEfsmBRg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3118,9 +3118,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
       resolve: 1.22.2
-      rollup: 3.25.1
+      rollup: 3.27.0
       tslib: 2.5.3
       typescript: 5.1.3
     dev: true
@@ -3140,12 +3140,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
       resolve: 1.22.2
       typescript: 5.1.3
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@3.25.1):
+  /@rollup/pluginutils@5.0.2(rollup@3.27.0):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3157,7 +3157,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.25.1
+      rollup: 3.27.0
 
   /@sideway/address@4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
@@ -3424,18 +3424,18 @@ packages:
       '@types/node': 18.15.11
     dev: true
 
-  /@vitejs/plugin-react-swc@3.3.2(vite@4.3.9):
+  /@vitejs/plugin-react-swc@3.3.2(vite@4.4.8):
     resolution: {integrity: sha512-VJFWY5sfoZerQRvJrh518h3AcQt6f/yTuWn4/TRB+dqmYU0NX1qz7qM5Wfd+gOQqUzQW4gxKqKN3KpE/P3+zrA==}
     peerDependencies:
       vite: ^4
     dependencies:
       '@swc/core': 1.3.70
-      vite: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+      vite: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
 
-  /@vitejs/plugin-react@4.0.1(vite@4.3.9):
+  /@vitejs/plugin-react@4.0.1(vite@4.4.8):
     resolution: {integrity: sha512-g25lL98essfeSj43HJ0o4DMp0325XK0ITkxpgChzJU/CyemgyChtlxfnRbjfwxDGCTRxTiXtQAsdebQXKMRSOA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -3445,7 +3445,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.22.5)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.22.5)
       react-refresh: 0.14.0
-      vite: 4.3.9(@types/node@18.15.11)(sass@1.63.6)
+      vite: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4289,6 +4289,7 @@ packages:
 
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    requiresBuild: true
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -4444,34 +4445,34 @@ packages:
       is-arrayish: 0.2.1
     dev: true
 
-  /esbuild@0.17.19:
-    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
+  /esbuild@0.18.17:
+    resolution: {integrity: sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.19
-      '@esbuild/android-arm64': 0.17.19
-      '@esbuild/android-x64': 0.17.19
-      '@esbuild/darwin-arm64': 0.17.19
-      '@esbuild/darwin-x64': 0.17.19
-      '@esbuild/freebsd-arm64': 0.17.19
-      '@esbuild/freebsd-x64': 0.17.19
-      '@esbuild/linux-arm': 0.17.19
-      '@esbuild/linux-arm64': 0.17.19
-      '@esbuild/linux-ia32': 0.17.19
-      '@esbuild/linux-loong64': 0.17.19
-      '@esbuild/linux-mips64el': 0.17.19
-      '@esbuild/linux-ppc64': 0.17.19
-      '@esbuild/linux-riscv64': 0.17.19
-      '@esbuild/linux-s390x': 0.17.19
-      '@esbuild/linux-x64': 0.17.19
-      '@esbuild/netbsd-x64': 0.17.19
-      '@esbuild/openbsd-x64': 0.17.19
-      '@esbuild/sunos-x64': 0.17.19
-      '@esbuild/win32-arm64': 0.17.19
-      '@esbuild/win32-ia32': 0.17.19
-      '@esbuild/win32-x64': 0.17.19
+      '@esbuild/android-arm': 0.18.17
+      '@esbuild/android-arm64': 0.18.17
+      '@esbuild/android-x64': 0.18.17
+      '@esbuild/darwin-arm64': 0.18.17
+      '@esbuild/darwin-x64': 0.18.17
+      '@esbuild/freebsd-arm64': 0.18.17
+      '@esbuild/freebsd-x64': 0.18.17
+      '@esbuild/linux-arm': 0.18.17
+      '@esbuild/linux-arm64': 0.18.17
+      '@esbuild/linux-ia32': 0.18.17
+      '@esbuild/linux-loong64': 0.18.17
+      '@esbuild/linux-mips64el': 0.18.17
+      '@esbuild/linux-ppc64': 0.18.17
+      '@esbuild/linux-riscv64': 0.18.17
+      '@esbuild/linux-s390x': 0.18.17
+      '@esbuild/linux-x64': 0.18.17
+      '@esbuild/netbsd-x64': 0.18.17
+      '@esbuild/openbsd-x64': 0.18.17
+      '@esbuild/sunos-x64': 0.18.17
+      '@esbuild/win32-arm64': 0.18.17
+      '@esbuild/win32-ia32': 0.18.17
+      '@esbuild/win32-x64': 0.18.17
     dev: true
 
   /escalade@3.1.1:
@@ -4940,6 +4941,7 @@ packages:
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
     dev: true
@@ -6354,6 +6356,7 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -6675,6 +6678,7 @@ packages:
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -7093,6 +7097,15 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /postcss@8.4.27:
+    resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -7118,6 +7131,7 @@ packages:
 
   /prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -8146,8 +8160,8 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
-  /rollup@3.25.1:
-    resolution: {integrity: sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==}
+  /rollup@3.27.0:
+    resolution: {integrity: sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -8196,6 +8210,7 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -8211,6 +8226,7 @@ packages:
 
   /sax@1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -8237,6 +8253,7 @@ packages:
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
     hasBin: true
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -8901,13 +8918,14 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  /vite@4.3.9(@types/node@18.15.11)(sass@1.63.6):
-    resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
+  /vite@4.4.8(@types/node@18.15.11)(sass@1.63.6):
+    resolution: {integrity: sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
+      lightningcss: ^1.21.0
       sass: '*'
       stylus: '*'
       sugarss: '*'
@@ -8916,6 +8934,8 @@ packages:
       '@types/node':
         optional: true
       less:
+        optional: true
+      lightningcss:
         optional: true
       sass:
         optional: true
@@ -8927,9 +8947,9 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.15.11
-      esbuild: 0.17.19
-      postcss: 8.4.24
-      rollup: 3.25.1
+      esbuild: 0.18.17
+      postcss: 8.4.27
+      rollup: 3.27.0
       sass: 1.63.6
     optionalDependencies:
       fsevents: 2.3.2


### PR DESCRIPTION
Fixes ecosystem-ci fail.

Both `vite` and `rollup` needs to be upgraded as Vite uses a newer version of Rollup and its types doesn't match across versions.