### PR TITLE
chore: update rollup

### DIFF
--- a/packages/react-pages/package.json
+++ b/packages/react-pages/package.json
@@ -61,7 +61,7 @@
     "concurrently": "^7.6.0",
     "react": "^18.2.0",
     "rimraf": "^4.4.1",
-    "rollup": "^3.28.1",
+    "rollup": "^3.29.2",
     "typescript": "^4.3.2",
     "vite": "^4.4.8"
   },

--- a/packages/theme-doc/package.json
+++ b/packages/theme-doc/package.json
@@ -64,7 +64,7 @@
     "prism-react-renderer": "^1.3.5",
     "rc-footer": "^0.6.8",
     "rimraf": "^4.4.1",
-    "rollup": "^3.28.1",
+    "rollup": "^3.29.2",
     "rollup-plugin-postcss": "^4.0.0",
     "tslib": "^2.5.3",
     "typescript": "^5.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,7 +501,7 @@ importers:
     dependencies:
       '@mdx-js/rollup':
         specifier: ^2.3.0
-        version: 2.3.0(rollup@3.28.1)
+        version: 2.3.0(rollup@3.29.2)
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -583,16 +583,16 @@ importers:
         version: 7.22.5(@babel/core@7.22.5)
       '@rollup/plugin-babel':
         specifier: ^6.0.3
-        version: 6.0.3(@babel/core@7.22.5)(rollup@3.28.1)
+        version: 6.0.3(@babel/core@7.22.5)(rollup@3.29.2)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.2
-        version: 25.0.2(rollup@3.28.1)
+        version: 25.0.2(rollup@3.29.2)
       '@rollup/plugin-node-resolve':
         specifier: ^15.1.0
-        version: 15.1.0(rollup@3.28.1)
+        version: 15.1.0(rollup@3.29.2)
       '@rollup/plugin-typescript':
         specifier: ^11.1.1
-        version: 11.1.1(rollup@3.28.1)(tslib@2.5.3)(typescript@5.1.3)
+        version: 11.1.1(rollup@3.29.2)(tslib@2.5.3)(typescript@5.1.3)
       '@types/fs-extra':
         specifier: ^11.0.1
         version: 11.0.1
@@ -618,8 +618,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       rollup:
-        specifier: ^3.28.1
-        version: 3.28.1
+        specifier: ^3.29.2
+        version: 3.29.2
       vite:
         specifier: ^4.4.8
         version: 4.4.8(@types/node@18.15.11)(sass@1.63.6)
@@ -640,16 +640,16 @@ importers:
         version: 7.22.5(@babel/core@7.22.5)
       '@rollup/plugin-babel':
         specifier: ^6.0.3
-        version: 6.0.3(@babel/core@7.22.5)(rollup@3.28.1)
+        version: 6.0.3(@babel/core@7.22.5)(rollup@3.29.2)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.2
-        version: 25.0.2(rollup@3.28.1)
+        version: 25.0.2(rollup@3.29.2)
       '@rollup/plugin-node-resolve':
         specifier: ^15.1.0
-        version: 15.1.0(rollup@3.28.1)
+        version: 15.1.0(rollup@3.29.2)
       '@rollup/plugin-typescript':
         specifier: ^11.1.1
-        version: 11.1.1(rollup@3.28.1)(tslib@2.5.3)(typescript@5.1.3)
+        version: 11.1.1(rollup@3.29.2)(tslib@2.5.3)(typescript@5.1.3)
       '@types/mdx':
         specifier: ^2.0.5
         version: 2.0.5
@@ -699,8 +699,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       rollup:
-        specifier: ^3.28.1
-        version: 3.28.1
+        specifier: ^3.29.2
+        version: 3.29.2
       rollup-plugin-postcss:
         specifier: ^4.0.0
         version: 4.0.2(postcss@8.4.24)(ts-node@10.9.1)
@@ -2733,7 +2733,7 @@ packages:
       react: 18.2.0
     dev: true
 
-  /@mdx-js/rollup@2.3.0(rollup@3.28.1):
+  /@mdx-js/rollup@2.3.0(rollup@3.29.2):
     resolution: {integrity: sha512-wLvRfJS/M4UmdqTd+WoaySEE7q4BIejYf1xAHXYvtT1du/1Tl/z2450Gg2+Hu7fh05KwRRiehiTP9Yc/Dtn0fA==}
     peerDependencies:
       rollup: '>=2'
@@ -2742,8 +2742,8 @@ packages:
         optional: true
     dependencies:
       '@mdx-js/mdx': 2.3.0
-      '@rollup/pluginutils': 5.0.2(rollup@3.28.1)
-      rollup: 3.28.1
+      '@rollup/pluginutils': 5.0.2(rollup@3.29.2)
+      rollup: 3.29.2
       source-map: 0.7.4
       vfile: 5.3.7
     transitivePeerDependencies:
@@ -3046,7 +3046,7 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /@rollup/plugin-babel@6.0.3(@babel/core@7.22.5)(rollup@3.28.1):
+  /@rollup/plugin-babel@6.0.3(@babel/core@7.22.5)(rollup@3.29.2):
     resolution: {integrity: sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3063,11 +3063,11 @@ packages:
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-module-imports': 7.18.6
-      '@rollup/pluginutils': 5.0.2(rollup@3.28.1)
-      rollup: 3.28.1
+      '@rollup/pluginutils': 5.0.2(rollup@3.29.2)
+      rollup: 3.29.2
     dev: true
 
-  /@rollup/plugin-commonjs@25.0.2(rollup@3.28.1):
+  /@rollup/plugin-commonjs@25.0.2(rollup@3.29.2):
     resolution: {integrity: sha512-NGTwaJxIO0klMs+WSFFtBP7b9TdTJ3K76HZkewT8/+yHzMiUGVQgaPtLQxNVYIgT5F7lxkEyVID+yS3K7bhCow==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3076,16 +3076,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.28.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.29.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.28.1
+      rollup: 3.29.2
     dev: true
 
-  /@rollup/plugin-node-resolve@15.1.0(rollup@3.28.1):
+  /@rollup/plugin-node-resolve@15.1.0(rollup@3.29.2):
     resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3094,16 +3094,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.28.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.29.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.2
-      rollup: 3.28.1
+      rollup: 3.29.2
     dev: true
 
-  /@rollup/plugin-typescript@11.1.1(rollup@3.28.1)(tslib@2.5.3)(typescript@5.1.3):
+  /@rollup/plugin-typescript@11.1.1(rollup@3.29.2)(tslib@2.5.3)(typescript@5.1.3):
     resolution: {integrity: sha512-Ioir+x5Bejv72Lx2Zbz3/qGg7tvGbxQZALCLoJaGrkNXak/19+vKgKYJYM3i/fJxvsb23I9FuFQ8CUBEfsmBRg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3118,9 +3118,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.28.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.29.2)
       resolve: 1.22.2
-      rollup: 3.28.1
+      rollup: 3.29.2
       tslib: 2.5.3
       typescript: 5.1.3
     dev: true
@@ -3140,12 +3140,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.28.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.29.2)
       resolve: 1.22.2
       typescript: 5.1.3
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@3.28.1):
+  /@rollup/pluginutils@5.0.2(rollup@3.29.2):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3157,7 +3157,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.28.1
+      rollup: 3.29.2
 
   /@sideway/address@4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
@@ -8168,8 +8168,8 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
-  /rollup@3.28.1:
-    resolution: {integrity: sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==}
+  /rollup@3.29.2:
+    resolution: {integrity: sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -8957,7 +8957,7 @@ packages:
       '@types/node': 18.15.11
       esbuild: 0.18.20
       postcss: 8.4.29
-      rollup: 3.28.1
+      rollup: 3.29.2
       sass: 1.63.6
     optionalDependencies:
       fsevents: 2.3.3


### PR DESCRIPTION
This PR simply updates rollup version.
This will fix ecosystem-ci fail that will be caused by https://github.com/vitejs/vite/pull/14238