### PR TITLE
refactor: use `config.build.ssr` instead of `env.ssrBuild`

### DIFF
--- a/packages/react-pages/src/node/index.ts
+++ b/packages/react-pages/src/node/index.ts
@@ -104,7 +104,7 @@ function pluginFactory(opts: PluginConfig = {}): Plugin {
       },
       define: {
         __HASH_ROUTER__: !!useHashRouter,
-        'process.env.VITE_PAGES_IS_SSR': env.ssrBuild
+        'process.env.VITE_PAGES_IS_SSR': config.build?.ssr
           ? JSON.stringify('true')
           : JSON.stringify('false'),
       },


### PR DESCRIPTION
In Vite 5, `env.ssrBuild` is renamed to `env.isSsrBuild` (https://github.com/vitejs/vite/pull/14855). But in this case, `config.build.ssr` can be used as well.
https://github.com/vitejs/vite/discussions/13809#:~:text=this%20could%20have%20been%20written%20using%20config.build.ssr%20instead%20as%20we%20recommend%20in%20the%20apply%20docs.
So I used that instead.

This will fix the ecosystem-ci failure: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6766541296/job/18407003513
